### PR TITLE
Fix user reserved word

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/User.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/User.java
@@ -9,14 +9,12 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
-import javax.persistence.Index;
 import javax.persistence.Table;
 import lombok.Data;
 
 @Entity
 @Data
-@Table(
-    name = "users")
+@Table(name = "users")
 public class User {
   @Id private UUID id;
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/User.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/User.java
@@ -9,10 +9,14 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import lombok.Data;
 
 @Entity
 @Data
+@Table(
+    name = "users")
 public class User {
   @Id private UUID id;
 


### PR DESCRIPTION
# Motivation and Context
`user` is a reserved word in SQL. Causes problems with DDL and stuff.

# What has changed
Changed user table to be called users... same solution as with cases table.

# How to test?
Start everything. Does it work?

# Links
Trello: https://trello.com/c/EJIfiW4G