### PR TITLE
Reduce log chattiness

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
@@ -41,7 +41,7 @@ public class ClusterLeaderManager {
       clusterLeaderRepository.saveAndFlush(clusterLeader);
 
       log.with("hostName", hostName)
-          .info("No leader existed in DB, so this host is attempting to become leader");
+          .debug("No leader existed in DB, so this host is attempting to become leader");
     }
 
     Optional<ClusterLeader> lockedClusterLeaderOpt =
@@ -49,14 +49,14 @@ public class ClusterLeaderManager {
 
     if (!lockedClusterLeaderOpt.isPresent()) {
       log.with("hostName", hostName)
-          .info("Could not get leader row, presumably because of lock contention");
+          .debug("Could not get leader row, presumably because of lock contention");
       return false;
     }
 
     ClusterLeader clusterLeader = lockedClusterLeaderOpt.get();
 
     if (clusterLeader.getHostName().equals(hostName)) {
-      log.with("hostName", hostName).info("This host is leader");
+      log.with("hostName", hostName).debug("This host is leader");
       return true;
     } else if (clusterLeader
         .getHostLastSeenAliveAt()
@@ -68,11 +68,11 @@ public class ClusterLeaderManager {
 
       log.with("oldHostName", oldHostName)
           .with("hostName", hostName)
-          .info("Leader has transferred from dead host to this host");
+          .debug("Leader has transferred from dead host to this host");
       return true;
     }
 
-    log.with("hostName", hostName).info("This host is not the leader");
+    log.with("hostName", hostName).debug("This host is not the leader");
     return false;
   }
 
@@ -91,7 +91,7 @@ public class ClusterLeaderManager {
       clusterLeader.setHostLastSeenAliveAt(OffsetDateTime.now());
       clusterLeaderRepository.saveAndFlush(clusterLeader);
 
-      log.with("hostName", hostName).info("Leader keepalive updated. This host is leader");
+      log.with("hostName", hostName).debug("Leader keepalive updated. This host is leader");
     }
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/WaveOfContactTriggerer.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/WaveOfContactTriggerer.java
@@ -2,6 +2,8 @@ package uk.gov.ons.ssdc.caseprocessor.schedule;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -15,9 +17,12 @@ public class WaveOfContactTriggerer {
   private final WaveOfContactRepository waveOfContactRepository;
   private final WaveOfContactProcessor waveOfContactProcessor;
 
+  private String hostName = InetAddress.getLocalHost().getHostName();
+
   public WaveOfContactTriggerer(
       WaveOfContactRepository waveOfContactRepository,
-      WaveOfContactProcessor waveOfContactProcessor) {
+      WaveOfContactProcessor waveOfContactProcessor)
+      throws UnknownHostException {
     this.waveOfContactRepository = waveOfContactRepository;
     this.waveOfContactProcessor = waveOfContactProcessor;
   }
@@ -30,7 +35,9 @@ public class WaveOfContactTriggerer {
 
     for (WaveOfContact triggeredWaveOfContact : triggeredWaveOfContacts) {
       try {
-        log.with("id", triggeredWaveOfContact.getId()).info("Wave of contact triggered");
+        log.with("hostName", hostName)
+            .with("id", triggeredWaveOfContact.getId())
+            .info("Wave of contact triggered");
         waveOfContactProcessor.createScheduledWaveOfContact(triggeredWaveOfContact);
       } catch (Exception e) {
         log.with("id", triggeredWaveOfContact.getId())

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/WaveOfContactTriggererTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/WaveOfContactTriggererTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.UnknownHostException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,7 +22,7 @@ public class WaveOfContactTriggererTest {
   private final WaveOfContactProcessor waveOfContactProcessor = mock(WaveOfContactProcessor.class);
 
   @Test
-  public void testTriggerWaveOfContact() {
+  public void testTriggerWaveOfContact() throws UnknownHostException {
     // Given
     WaveOfContact waveOfContact = new WaveOfContact();
     when(waveOfContactRepository.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(
@@ -38,7 +39,7 @@ public class WaveOfContactTriggererTest {
   }
 
   @Test
-  public void testTriggerMultipleWaveOfContact() {
+  public void testTriggerMultipleWaveOfContact() throws UnknownHostException {
     // Given
     List<WaveOfContact> waveOfContacts = new ArrayList<>(50);
     for (int i = 0; i < 50; i++) {


### PR DESCRIPTION
# Motivation and Context
Each case processor is logging 64 times per minute, which is quite chatty.

# What has changed
Reduced the cluster leader locking logging from info to debug.

# How to test?
Run it. Follow the logs.

# Links
Trello: https://trello.com/c/j269XaXl