### PR TITLE
Emit a CASE_CREATED event on sample load

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleReceiver.java
@@ -17,11 +17,13 @@ import uk.gov.ons.ssdc.caseprocessor.model.entity.CollectionExercise;
 import uk.gov.ons.ssdc.caseprocessor.model.entity.EventType;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.CaseRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.CollectionExerciseRepository;
+import uk.gov.ons.ssdc.caseprocessor.service.CaseService;
 import uk.gov.ons.ssdc.caseprocessor.utils.CaseRefGenerator;
 
 @MessageEndpoint
 public class SampleReceiver {
   private final CaseRepository caseRepository;
+  private final CaseService caseService;
   private final CollectionExerciseRepository collectionExerciseRepository;
   private final EventLogger eventLogger;
 
@@ -30,9 +32,11 @@ public class SampleReceiver {
 
   public SampleReceiver(
       CaseRepository caseRepository,
+      CaseService caseService,
       CollectionExerciseRepository collectionExerciseRepository,
       EventLogger eventLogger) {
     this.caseRepository = caseRepository;
+    this.caseService = caseService;
     this.collectionExerciseRepository = collectionExerciseRepository;
     this.eventLogger = eventLogger;
   }
@@ -63,6 +67,7 @@ public class SampleReceiver {
     newCase.setSample(sample.getSample());
 
     newCase = saveNewCaseAndStampCaseRef(newCase);
+    caseService.emitCaseCreatedEvent(newCase);
 
     eventLogger.logCaseEvent(
         newCase,

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -39,6 +39,15 @@ public class CaseService {
         outboundExchange, CASE_UPDATE_ROUTING_KEY, responseManagementEvent);
   }
 
+  public void emitCaseCreatedEvent(Case caze) {
+    EventDTO eventDTO = new EventDTO();
+    eventDTO.setType(EventTypeDTO.CASE_CREATED);
+    eventDTO.setChannel("RM");
+    ResponseManagementEvent responseManagementEvent = prepareCaseEvent(caze, eventDTO);
+    rabbitTemplate.convertAndSend(
+        outboundExchange, CASE_UPDATE_ROUTING_KEY, responseManagementEvent);
+  }
+
   private ResponseManagementEvent prepareCaseEvent(Case caze, EventDTO eventDTO) {
     PayloadDTO payloadDTO = new PayloadDTO();
     CollectionCase collectionCase = new CollectionCase();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleLoadedIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleLoadedIT.java
@@ -1,12 +1,14 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_CASE_QUEUE;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,6 +19,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.CollectionCase;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.ResponseManagementEvent;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.Sample;
 import uk.gov.ons.ssdc.caseprocessor.model.entity.Case;
 import uk.gov.ons.ssdc.caseprocessor.model.entity.CollectionExercise;
@@ -27,6 +31,7 @@ import uk.gov.ons.ssdc.caseprocessor.model.repository.CollectionExerciseReposito
 import uk.gov.ons.ssdc.caseprocessor.model.repository.EventRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.UacQidLinkRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.WaveOfContactRepository;
+import uk.gov.ons.ssdc.caseprocessor.testutils.QueueSpy;
 import uk.gov.ons.ssdc.caseprocessor.testutils.RabbitQueueHelper;
 import uk.gov.ons.ssdc.caseprocessor.testutils.TestHelper;
 
@@ -52,6 +57,7 @@ public class SampleLoadedIT {
   @Transactional
   public void setUp() {
     rabbitQueueHelper.purgeQueue(inboundQueue);
+    rabbitQueueHelper.purgeQueue(OUTBOUND_CASE_QUEUE);
     eventRepository.deleteAllInBatch();
     uacQidLinkRepository.deleteAllInBatch();
     caseRepository.deleteAllInBatch();
@@ -61,29 +67,38 @@ public class SampleLoadedIT {
 
   @Test
   public void testSampleLoaded() throws IOException, InterruptedException {
-    CollectionExercise collectionExercise = new CollectionExercise();
-    collectionExercise.setId(UUID.randomUUID());
-    collectionExerciseRepository.saveAndFlush(collectionExercise);
+    try (QueueSpy outboundCaseQueueSpy = rabbitQueueHelper.listen(OUTBOUND_CASE_QUEUE)) {
+      CollectionExercise collectionExercise = new CollectionExercise();
+      collectionExercise.setId(UUID.randomUUID());
+      collectionExerciseRepository.saveAndFlush(collectionExercise);
 
-    Map<String, String> sampleDto = new HashMap<>();
-    sampleDto.put("Address", "Tenby");
-    sampleDto.put("Org", "Brewery");
+      Map<String, String> sampleDto = new HashMap<>();
+      sampleDto.put("Address", "Tenby");
+      sampleDto.put("Org", "Brewery");
 
-    Sample sample = new Sample();
-    sample.setCaseId(TEST_CASE_ID);
-    sample.setCollectionExerciseId(collectionExercise.getId());
-    sample.setSample(sampleDto);
+      Sample sample = new Sample();
+      sample.setCaseId(TEST_CASE_ID);
+      sample.setCollectionExerciseId(collectionExercise.getId());
+      sample.setSample(sampleDto);
 
-    rabbitQueueHelper.sendMessage(inboundQueue, sample);
+      rabbitQueueHelper.sendMessage(inboundQueue, sample);
 
-    Case actualCase = testHelper.pollUntilCaseExists(TEST_CASE_ID);
+      //  THEN
+      ResponseManagementEvent actualResponseManagementEvent =
+          outboundCaseQueueSpy.checkExpectedMessageReceived();
 
-    assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID);
-    assertThat(actualCase.getCollectionExercise().getId()).isEqualTo(collectionExercise.getId());
-    assertThat(actualCase.getSample()).isEqualTo(sampleDto);
+      CollectionCase emittedCase = actualResponseManagementEvent.getPayload().getCollectionCase();
+      Assertions.assertThat(emittedCase.getCaseId()).isEqualTo(TEST_CASE_ID);
 
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    assertThat(events.get(0).getEventType()).isEqualTo(EventType.SAMPLE_LOADED);
+      Case actualCase = testHelper.pollUntilCaseExists(TEST_CASE_ID);
+
+      assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID);
+      assertThat(actualCase.getCollectionExercise().getId()).isEqualTo(collectionExercise.getId());
+      assertThat(actualCase.getSample()).isEqualTo(sampleDto);
+
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      assertThat(events.get(0).getEventType()).isEqualTo(EventType.SAMPLE_LOADED);
+    }
   }
 }


### PR DESCRIPTION
# Motivation and Context
A CASE_CREATED event needs to be emitted to all interested parties(queues) when a case is created on sample load.  

# What has changed
A CASE_CREATED event is emitted to the outbound events exchange.  Follows a similar pattern to that of the census-rm-case-processor.  Note - there are a few test queues that aren't required but these are being tidied up as part of a separate ticket in progress, along with the queue names.

# How to test?
- Build and run the tests
- Load a sample in and a CASE_CREATED event should be output for each case created from the sample.

# Links
- https://trello.com/c/GPErJ5Zi

