### PR TITLE
Fix leader election thread contention using locking

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
@@ -7,10 +7,14 @@ import java.net.UnknownHostException;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import uk.gov.ons.ssdc.caseprocessor.model.entity.ClusterLeader;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ClusterLeaderRepository;
 
@@ -18,6 +22,7 @@ import uk.gov.ons.ssdc.caseprocessor.model.repository.ClusterLeaderRepository;
 public class ClusterLeaderManager {
   private static final Logger log = LoggerFactory.getLogger(ClusterLeaderManager.class);
   private static final UUID LEADER_ID = UUID.fromString("e469807b-f2e2-47bd-acf6-74f8943ff3db");
+  private static final ReentrantLock lock = new ReentrantLock();
 
   private final ClusterLeaderRepository clusterLeaderRepository;
 
@@ -34,11 +39,38 @@ public class ClusterLeaderManager {
   @Transactional(isolation = Isolation.REPEATABLE_READ)
   public boolean isThisHostClusterLeader() {
     if (!clusterLeaderRepository.existsById(LEADER_ID)) {
+      boolean isLockAcquired;
+
+      // Obtain a lock, so that only one thread can possibly ever be attempting to declare that
+      // this host is the leader, by recording it in the database
+      try {
+        isLockAcquired = lock.tryLock(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException("Failed to get lock before thread interrupted");
+      }
+
+      // If we couldn't obtain a lock then we can't continue... throw an error and let spring retry
+      if (!isLockAcquired) {
+        throw new RuntimeException("Failed to get lock before timeout");
+      }
+
+      // Now we are locked, record that this host is the cluster leader in the database
       ClusterLeader clusterLeader = new ClusterLeader();
       clusterLeader.setId(LEADER_ID);
       clusterLeader.setHostName(hostName);
       clusterLeader.setHostLastSeenAliveAt(OffsetDateTime.now());
       clusterLeaderRepository.saveAndFlush(clusterLeader);
+
+      // Finally, only release the lock once the transaction has been committed (or rolled back)
+      if (TransactionSynchronizationManager.isSynchronizationActive()) {
+        TransactionSynchronizationManager.registerSynchronization(
+            new TransactionSynchronization() {
+              @Override
+              public void afterCompletion(int status) {
+                lock.unlock();
+              }
+            });
+      }
 
       log.with("hostName", hostName)
           .debug("No leader existed in DB, so this host is attempting to become leader");


### PR DESCRIPTION
# Motivation and Context
Multiple threads are in a race to record in the database that the host is the leader. This means that multiple attempts are made to write the same database row, resulting in this error: `ERROR: duplicate key value violates unique constraint "cluster_leader_pkey"`

This is harmless, but people are bound to whinge about the error in the logs.

# What has changed
Created a locking mechanism to lock out all but one thread from attempting to declare itself as cluster leader.

# How to test?
Ensure the `cluster_leader` table is empty, then start the case processor and check the logs for the error.

# Links
Trello: https://trello.com/c/6RLzuoyn