### PR TITLE
Fix bug with created date getting wiped out from UacQidLink

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiver.java
@@ -33,7 +33,7 @@ public class DeactivateUacReceiver {
 
     OffsetDateTime messageTimestamp = getMsgTimeStamp(message);
     uacQidLink.setActive(false);
-    uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+    uacQidLink = uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
 
     eventLogger.logUacQidEvent(
         uacQidLink,

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiver.java
@@ -41,7 +41,7 @@ public class ReceiptReceiver {
 
     if (uacQidLink.isActive()) {
       uacQidLink.setActive(false);
-      uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+      uacQidLink = uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
 
       if (uacQidLink.getCaze() != null) {
         Case caze = uacQidLink.getCaze();

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
@@ -131,8 +131,6 @@ public class PrintProcessor {
     uacQidLink.setQid(uacQidDTO.getQid());
     uacQidLink.setUac(uacQidDTO.getUac());
     uacQidLink.setCaze(caze);
-    uacQidLinkRepository.saveAndFlush(uacQidLink);
-
     uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
 
     return uacQidDTO;

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -50,6 +51,7 @@ public class DeactivateUacReceiverTest {
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setActive(true);
     when(uacService.findByQid("0123456789")).thenReturn(uacQidLink);
+    when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(uacQidLink);
 
     // When
     underTest.receiveMessage(message);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
@@ -60,6 +60,7 @@ public class ReceiptReceiverTest {
     uacQidLink.setActive(true);
 
     when(uacService.findByQid(any())).thenReturn(uacQidLink);
+    when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(uacQidLink);
 
     underTest.receiveMessage(message);
 
@@ -147,6 +148,7 @@ public class ReceiptReceiverTest {
     uacQidLink.setCaze(caze);
 
     when(uacService.findByQid(any())).thenReturn(uacQidLink);
+    when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(uacQidLink);
 
     underTest.receiveMessage(message);
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
@@ -22,13 +22,11 @@ import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PrintRow;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.UacQidDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.entity.*;
-import uk.gov.ons.ssdc.caseprocessor.model.repository.UacQidLinkRepository;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PrintProcessorTest {
   @Mock private RabbitTemplate rabbitTemplate;
   @Mock private UacQidCache uacQidCache;
-  @Mock private UacQidLinkRepository uacQidLinkRepository;
   @Mock private UacService uacService;
   @Mock private EventLogger eventLogger;
 
@@ -82,14 +80,13 @@ public class PrintProcessorTest {
     assertThat(actualPrintRow.getRow()).isEqualTo("\"123\"|\"test uac\"|\"bar\"");
 
     ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(uacQidLinkRepository).saveAndFlush(uacQidLinkCaptor.capture());
+    verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLinkCaptor.capture());
     UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
     assertThat(actualUacQidLink.getUac()).isEqualTo("test uac");
     assertThat(actualUacQidLink.getQid()).isEqualTo("test qid");
     assertThat(actualUacQidLink.getCaze()).isEqualTo(caze);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
-    verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLinkCaptor.getValue());
     verify(eventLogger)
         .logCaseEvent(
             eq(caze),
@@ -138,14 +135,13 @@ public class PrintProcessorTest {
     assertThat(actualPrintRow.getRow()).isEqualTo("\"123\"|\"test uac\"|\"bar\"");
 
     ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(uacQidLinkRepository).saveAndFlush(uacQidLinkCaptor.capture());
+    verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLinkCaptor.capture());
     UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
     assertThat(actualUacQidLink.getUac()).isEqualTo("test uac");
     assertThat(actualUacQidLink.getQid()).isEqualTo("test qid");
     assertThat(actualUacQidLink.getCaze()).isEqualTo(caze);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
-    verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLinkCaptor.getValue());
     verify(eventLogger)
         .logCaseEvent(
             eq(caze),


### PR DESCRIPTION
# Motivation and Context
When we use Hibernate/JPA/Spring Data to save stuff to the database, we need to do it properly.

Wrong:
```java
  MyEntity myEntity = new MyEntity();
  myRepository.save(myEntity);
  
  // do more stuff
  
  myRepository.save(myEntity); // NOPE! You just wiped out a bunch of stuff!
```  

Right:
```java
  MyEntity myEntity = new MyEntity();
  myEntity = myRepository.save(myEntity); // YES! This is how you do it!
  
  // do more stuff
  
  myRepository.save(myEntity);
```  

# What has changed
Fixed dodgy code.

# How to test?
However you want, but mainly, check that the created dates are not being destroyed any more on the UacQid links.

# Links
Trello: https://trello.com/c/hgu9MSur