### PR TITLE
Consistent routing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Just build the image
 ## Events
 
 ### Sample Load
-The case processor listens to a Rabbit queue called `supportTool.caseProcessor.sample`. The messages are JSON format and are of the following format:
+Queue name: `supportTool.caseProcessor.sample`
+Exchange: N/A
+Routing key: N/A
+
+Example message:
 
 ```json
 {
@@ -45,8 +49,11 @@ The case processor listens to a Rabbit queue called `supportTool.caseProcessor.s
 ```
 
 ### Invalid Address
-Queue Name: events.caseProcessor.invalidAddress
-Example Msg: 
+Queue name: `events.caseProcessor.invalidAddress`
+Exchange: `events`
+Routing key: `events.invalidAddress`
+
+Example message: 
 ```json
 {
   "event": {
@@ -67,8 +74,11 @@ Example Msg:
 ```
 
 ### Receipts/Responses
-Queue Name: events.caseProcessor.response
-Example Msg:
+Queue name: `events.caseProcessor.response`
+Exchange: `events`
+Routing key: `events.response`
+
+Example message:
 ```json
 {
   "event": {
@@ -88,8 +98,11 @@ Example Msg:
 ```
 
 ### Refusals
-Queue: events.caseProcessor.refusal
-Example Msg:
+Queue name: `events.caseProcessor.refusal`
+Exchange: `events`
+Routing key: `events.refusal`
+
+Example message:
 ```json
 {
   "event": {
@@ -116,8 +129,11 @@ Example Msg:
 ```
 
 ### Survey Launched
-queue: events.caseProcessor.surveyLaunched
-Example Msg:
+Queue name: `events.caseProcessor.surveyLaunched`
+Exchange: `events`
+Routing key: `events.surveyLaunched`
+
+Example message:
 ```json
 {
   "event": {
@@ -180,6 +196,10 @@ values ('b1d826fa-6afc-4270-9f0c-302cb05d4d96', -- trigger ID
 
 The fulfilments will only be triggered by the "leader" pod, in the event that multiple instances of the case processor are running. If the leader dies or is killed/terminated, then another leader will be elected after 2 minutes.
 
+Queue name: `events.caseProcessor.fulfilment`
+Exchange: `events`
+Routing key: `events.fulfilment`
+
 Example message:
 ```json
 {
@@ -202,6 +222,10 @@ Example message:
 ## Update Sensitive Data
 If we want to change or blank out (i.e. 'delete') sensitive data, such as phone numbers, email addresses, or respondent names, to comply with GDPR right to rectification laws, then we can handle messages to fix that data as required.
 
+Queue name: `events.caseProcessor.updateSampleSensitive`
+Exchange: `events`
+Routing key: `events.updateSampleSensitive`
+
 Example message:
 ```json
 {
@@ -216,6 +240,29 @@ Example message:
     "updateSampleSensitive": {
       "caseId": "3b768940-6ef2-460e-bb75-e51d3a65ada4",
       "sampleSensitive": {"PHONE_NUMBER":"this is not a real phone number innit"}
+    }
+  }
+}
+```
+
+## Deactivate UAC
+Queue name: `events.caseProcessor.deactivateUac`
+Exchange: `events`
+Routing key: `events.deactivateUac`
+
+Example message:
+```json
+{
+  "event": {
+    "type": "DEACTIVATE_UAC",
+    "source": "RH",
+    "channel": "RH",
+    "dateTime": "2021-06-09T13:49:19.716761Z",
+    "transactionId": "92df974c-f03e-4519-8d55-05e9c0ecea43"
+  },
+  "payload": {
+    "deactivateUac": {
+      "qid": "0123456789"
     }
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -16,12 +16,14 @@ import uk.gov.ons.ssdc.caseprocessor.model.repository.CaseRepository;
 
 @Service
 public class CaseService {
-  public static final String CASE_UPDATE_ROUTING_KEY = "events.rh.caseUpdate";
   private final CaseRepository caseRepository;
   private final RabbitTemplate rabbitTemplate;
 
   @Value("${queueconfig.case-event-exchange}")
   private String outboundExchange;
+
+  @Value("${queueconfig.case-update-routing-key}")
+  private String caseUpdateRoutingKey;
 
   public CaseService(CaseRepository caseRepository, RabbitTemplate rabbitTemplate) {
     this.caseRepository = caseRepository;
@@ -35,8 +37,7 @@ public class CaseService {
     eventDTO.setType(EventTypeDTO.CASE_UPDATED);
     eventDTO.setChannel("RM");
     ResponseManagementEvent responseManagementEvent = prepareCaseEvent(caze, eventDTO);
-    rabbitTemplate.convertAndSend(
-        outboundExchange, CASE_UPDATE_ROUTING_KEY, responseManagementEvent);
+    rabbitTemplate.convertAndSend(outboundExchange, caseUpdateRoutingKey, responseManagementEvent);
   }
 
   public void saveCase(Case caze) {
@@ -48,8 +49,7 @@ public class CaseService {
     eventDTO.setType(EventTypeDTO.CASE_CREATED);
     eventDTO.setChannel("RM");
     ResponseManagementEvent responseManagementEvent = prepareCaseEvent(caze, eventDTO);
-    rabbitTemplate.convertAndSend(
-        outboundExchange, CASE_UPDATE_ROUTING_KEY, responseManagementEvent);
+    rabbitTemplate.convertAndSend(outboundExchange, caseUpdateRoutingKey, responseManagementEvent);
   }
 
   private ResponseManagementEvent prepareCaseEvent(Case caze, EventDTO eventDTO) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessor.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.ssdc.caseprocessor.service;
 
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.DEACTIVATE_UAC_ROUTING_KEY;
-
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -23,6 +21,9 @@ public class DeactivateUacProcessor {
   @Value("${queueconfig.case-event-exchange}")
   private String outboundExchange;
 
+  @Value("${queueconfig.deactivate-uac-routing-key}")
+  private String deactivateUacRoutingKey;
+
   public DeactivateUacProcessor(RabbitTemplate rabbitTemplate) {
     this.rabbitTemplate = rabbitTemplate;
   }
@@ -34,7 +35,7 @@ public class DeactivateUacProcessor {
       if (uacQidLink.isActive()) {
         ResponseManagementEvent responseManagementEvent = prepareDeactivateUacEvent(uacQidLink);
         rabbitTemplate.convertAndSend(
-            outboundExchange, DEACTIVATE_UAC_ROUTING_KEY, responseManagementEvent);
+            outboundExchange, deactivateUacRoutingKey, responseManagementEvent);
       }
     }
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
@@ -16,13 +16,14 @@ import uk.gov.ons.ssdc.caseprocessor.utils.EventHelper;
 
 @Service
 public class UacService {
-  private static final String UAC_UPDATE_ROUTING_KEY = "events.rh.uacUpdate";
-
   private final UacQidLinkRepository uacQidLinkRepository;
   private final RabbitTemplate rabbitTemplate;
 
   @Value("${queueconfig.case-event-exchange}")
   private String outboundExchange;
+
+  @Value("${queueconfig.uac-update-routing-key}")
+  private String uacUpdateRoutingKey;
 
   public UacService(UacQidLinkRepository uacQidLinkRepository, RabbitTemplate rabbitTemplate) {
     this.rabbitTemplate = rabbitTemplate;
@@ -52,8 +53,7 @@ public class UacService {
     responseManagementEvent.setEvent(eventDTO);
     responseManagementEvent.setPayload(payloadDTO);
 
-    rabbitTemplate.convertAndSend(
-        outboundExchange, UAC_UPDATE_ROUTING_KEY, responseManagementEvent);
+    rabbitTemplate.convertAndSend(outboundExchange, uacUpdateRoutingKey, responseManagementEvent);
 
     return savedUacQidLink;
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
@@ -1,5 +1,0 @@
-package uk.gov.ons.ssdc.caseprocessor.utils;
-
-public class Constants {
-  public static final String DEACTIVATE_UAC_ROUTING_KEY = "events.caseProcessor.deactivateUac";
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,9 @@ queueconfig:
   fulfilment-queue: events.caseProcessor.fulfilment
   deactivate-uac-queue: events.caseProcessor.deactivateUac
   update-sample-sensitive-queue: events.caseProcessor.updateSampleSensitive
+  case-update-routing-key: events.caseUpdate
+  uac-update-routing-key: events.uacUpdate
+  deactivate-uac-routing-key: events.deactivateUac
   case-event-exchange: events
   consumers: 50
   retry-attempts: 3

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverIT.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_QUEUE;
 
 import java.util.UUID;
 import org.junit.Before;
@@ -34,8 +35,6 @@ import uk.gov.ons.ssdc.caseprocessor.testutils.RabbitQueueHelper;
 public class DeactivateUacReceiverIT {
   private static final String TEST_QID = "0123456789";
 
-  private static final String caseRhUacQueue = "events.rh.uacUpdate";
-
   @Value("${queueconfig.deactivate-uac-queue}")
   private String deactivateUacQueue;
 
@@ -47,14 +46,14 @@ public class DeactivateUacReceiverIT {
   @Transactional
   public void setUp() {
     rabbitQueueHelper.purgeQueue(deactivateUacQueue);
-    rabbitQueueHelper.purgeQueue(caseRhUacQueue);
+    rabbitQueueHelper.purgeQueue(OUTBOUND_UAC_QUEUE);
     eventRepository.deleteAllInBatch();
     uacQidLinkRepository.deleteAllInBatch();
   }
 
   @Test
   public void testDeactivateUacReceiver() throws Exception {
-    try (QueueSpy uacRhQueue = rabbitQueueHelper.listen(caseRhUacQueue)) {
+    try (QueueSpy uacRhQueue = rabbitQueueHelper.listen(OUTBOUND_UAC_QUEUE)) {
       // GIVEN
       ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
       EventDTO eventDTO = new EventDTO();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessorTest.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ssdc.caseprocessor.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.DEACTIVATE_UAC_ROUTING_KEY;
 
 import java.util.List;
 import org.junit.Test;
@@ -30,6 +29,7 @@ public class DeactivateUacProcessorTest {
   public void testProcessDeactivateUacRow() {
     // Given
     ReflectionTestUtils.setField(underTest, "outboundExchange", "testExchange");
+    ReflectionTestUtils.setField(underTest, "deactivateUacRoutingKey", "testRoutingKey");
 
     Case caze = new Case();
 
@@ -46,7 +46,7 @@ public class DeactivateUacProcessorTest {
     verify(rabbitTemplate)
         .convertAndSend(
             eq("testExchange"),
-            eq(DEACTIVATE_UAC_ROUTING_KEY),
+            eq("testRoutingKey"),
             responseManagementEventArgumentCaptor.capture());
     DeactivateUacDTO actualDeactivateUac =
         responseManagementEventArgumentCaptor.getValue().getPayload().getDeactivateUac();

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -183,7 +183,16 @@
       "vhost": "/",
       "destination": "events.caseProcessor.updateSampleSensitive",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.updateSampleSensitive",
+      "routing_key": "events.updateSampleSensitive",
+      "arguments": {
+      }
+    },
+    {
+      "source": "events",
+      "vhost": "/",
+      "destination": "events.caseProcessor.fulfilment",
+      "destination_type": "queue",
+      "routing_key": "events.fulfilment",
       "arguments": {
       }
     },
@@ -192,7 +201,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.refusal",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.refusal",
+      "routing_key": "events.refusal",
       "arguments": {
       }
     },
@@ -201,7 +210,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.response",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.response",
+      "routing_key": "events.response",
       "arguments": {
       }
     },
@@ -210,7 +219,7 @@
       "vhost": "/",
       "destination": "events.rh.uacUpdate",
       "destination_type": "queue",
-      "routing_key": "events.rh.uacUpdate",
+      "routing_key": "events.uacUpdate",
       "arguments": {
       }
     },
@@ -228,7 +237,7 @@
       "vhost": "/",
       "destination": "events.rh.caseUpdate",
       "destination_type": "queue",
-      "routing_key": "events.rh.caseUpdate",
+      "routing_key": "events.caseUpdate",
       "arguments": {
       }
     },
@@ -246,7 +255,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.invalidAddress",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.invalidAddress",
+      "routing_key": "events.invalidAddress",
       "arguments": {}
     },
     {
@@ -254,7 +263,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.surveyLaunched",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.surveyLaunched",
+      "routing_key": "events.surveyLaunched",
       "arguments": {
       }
     },
@@ -263,7 +272,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.deactivateUac",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.deactivateUac",
+      "routing_key": "events.deactivateUac",
       "arguments": {
       }
     },


### PR DESCRIPTION
# Motivation and Context
Routing key != queue name. If you want to send directly to a queue, use the default exchange. Otherwise, use the `events` exchange with a meaningful routing key.

# What has changed
Named the routing keys better.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/4CgML4w6