### PR TITLE
Allow sample with different delimiter & no header to be loaded

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/Survey.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/Survey.java
@@ -26,6 +26,10 @@ public class Survey {
   @Column(columnDefinition = "jsonb")
   private String sampleValidationRules;
 
+  @Column private boolean sampleWithHeaderRow;
+
+  @Column private char sampleSeparator;
+
   @OneToMany(mappedBy = "survey")
   private List<CollectionExercise> collectionExercises;
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/FulfilmentIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/FulfilmentIT.java
@@ -136,6 +136,7 @@ public class FulfilmentIT {
   private Survey setUpSurvey() {
     Survey survey = new Survey();
     survey.setId(UUID.randomUUID());
+    survey.setSampleSeparator(',');
     return surveyRepository.saveAndFlush(survey);
   }
 


### PR DESCRIPTION
# Motivation and Context
We can't currently load business samples into _Strategic_ Survey Data Collection, because we insist on there being a header row, and we expect regular vanilla CSV (C standing for comma, not colon).

# What has changed
Added flag to indicate sample has no header row, and configurable sample file seperator.

# How to test?
Try loading a business sample.

# Links
Trello: https://trello.com/c/Ies3dYbl