### PR TITLE
Improve wording of print file generation

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
@@ -109,7 +109,7 @@ public class PrintProcessor {
     eventLogger.logCaseEvent(
         caze,
         OffsetDateTime.now(),
-        String.format("Printed pack code %s with batch id %s", packCode, batchId.toString()),
+        String.format("Print file generated with pack code %s", packCode),
         EventType.PRINTED_PACK_CODE,
         getDummyEvent(),
         null,

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
@@ -91,8 +91,7 @@ public class PrintProcessorTest {
         .logCaseEvent(
             eq(caze),
             any(OffsetDateTime.class),
-            eq(
-                "Printed pack code test pack code with batch id 6a127d58-c1cb-489c-a3f5-72014a0c32d6"),
+            eq("Print file generated with pack code test pack code"),
             eq(EventType.PRINTED_PACK_CODE),
             any(EventDTO.class),
             isNull(),
@@ -146,8 +145,7 @@ public class PrintProcessorTest {
         .logCaseEvent(
             eq(caze),
             any(OffsetDateTime.class),
-            eq(
-                "Printed pack code TEST_FULFILMENT_CODE with batch id 6a127d58-c1cb-489c-a3f5-72014a0c32d6"),
+            eq("Print file generated with pack code TEST_FULFILMENT_CODE"),
             eq(EventType.PRINTED_PACK_CODE),
             any(EventDTO.class),
             isNull(),


### PR DESCRIPTION
# Motivation and Context
Wording was unclear for users, perhaps leading them to believe that printed materials had been posted out to respondents, when it had not.

# What has changed
Changed wording to make it clear that a file has been generated, but has probably not been sent to the printer supplier yet.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/qIdPbsJG