### PR TITLE
Removal of Bad Events

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleReceiver.java
@@ -77,7 +77,7 @@ public class SampleReceiver {
         newCase,
         OffsetDateTime.now(),
         "Create case sample received",
-        EventType.SAMPLE_LOADED,
+        EventType.CASE_CREATED,
         createEventDTO(EventTypeDTO.SAMPLE_LOADED),
         RedactHelper.redact(message.getPayload()),
         messageTimestamp);

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/EventType.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/EventType.java
@@ -2,10 +2,8 @@ package uk.gov.ons.ssdc.caseprocessor.model.entity;
 
 public enum EventType {
   CASE_CREATED,
-  UAC_UPDATED,
   RESPONSE_RECEIVED,
   REFUSAL_RECEIVED,
-  SAMPLE_LOADED,
   SURVEY_LAUNCHED,
   ADDRESS_NOT_VALID,
   RESPONDENT_AUTHENTICATED,

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/logging/EventLoggerTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/logging/EventLoggerTest.java
@@ -43,7 +43,7 @@ public class EventLoggerTest {
         caze,
         eventTime,
         "Test description",
-        EventType.UAC_UPDATED,
+        EventType.CASE_CREATED,
         eventDTO,
         redactMe,
         messageTime);
@@ -56,7 +56,7 @@ public class EventLoggerTest {
     assertThat(eventTime).isEqualTo(actualEvent.getEventDate());
     assertThat("Test source").isEqualTo(actualEvent.getEventSource());
     assertThat("Test channel").isEqualTo(actualEvent.getEventChannel());
-    assertThat(EventType.UAC_UPDATED).isEqualTo(actualEvent.getEventType());
+    assertThat(EventType.CASE_CREATED).isEqualTo(actualEvent.getEventType());
     assertThat("Test description").isEqualTo(actualEvent.getEventDescription());
     assertThat("{\"uac\":\"SECRET UAC\",\"qid\":\"TEST QID\"}")
         .isEqualTo(actualEvent.getEventPayload());
@@ -81,7 +81,7 @@ public class EventLoggerTest {
         uacQidLink,
         eventTime,
         "Test description",
-        EventType.UAC_UPDATED,
+        EventType.CASE_CREATED,
         eventDTO,
         redactMe,
         messageTime);
@@ -94,7 +94,7 @@ public class EventLoggerTest {
     assertThat(eventTime).isEqualTo(actualEvent.getEventDate());
     assertThat("Test source").isEqualTo(actualEvent.getEventSource());
     assertThat("Test channel").isEqualTo(actualEvent.getEventChannel());
-    assertThat(EventType.UAC_UPDATED).isEqualTo(actualEvent.getEventType());
+    assertThat(EventType.CASE_CREATED).isEqualTo(actualEvent.getEventType());
     assertThat("Test description").isEqualTo(actualEvent.getEventDescription());
     assertThat("{\"uac\":\"SECRET UAC\",\"qid\":\"TEST QID\"}")
         .isEqualTo(actualEvent.getEventPayload());

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleLoadedIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleLoadedIT.java
@@ -94,7 +94,7 @@ public class SampleLoadedIT {
 
       List<Event> events = eventRepository.findAll();
       assertThat(events.size()).isEqualTo(1);
-      assertThat(events.get(0).getEventType()).isEqualTo(EventType.SAMPLE_LOADED);
+      assertThat(events.get(0).getEventType()).isEqualTo(EventType.CASE_CREATED);
     }
   }
 }


### PR DESCRIPTION
# Motivation and Context
CASE_CREATED & UAC_UPDATED are unused (database) event types.
SAMPLE_LOADED is misleading, because it does not tell us when a sample was loaded, but in fact when we received an instruction to create a case.
We should get rid of SAMPLE_LOADED and UAC_UPDATED and store a CASE_CREATED when we create a case.

# What has changed
Removal of bad events
Updated tests

# How to test?
Build images and run ATs

# Links
https://trello.com/c/JnLxj02F
