### PR TITLE
Fix broken ITs because of new health endpoint for UAC-QID Service

### DIFF
--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
       - SPRING_PROFILES_ACTIVE=dev
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8164/actuator/info"]
+      test: ["CMD", "curl", "-f", "http://localhost:8164/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
# Motivation and Context
Integration tests fail because UAC-QID service is never seen as healthy.

# What has changed
Pointed healthcheck at correct endpoint.

# How to test?
Build with `mvn clean install` and it should pass.

# Links
Trello: https://trello.com/c/fNCyBh3m