### PR TITLE
Replace deprecated StringUtils.isEmpty with hasText

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/CaseClassifier.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/CaseClassifier.java
@@ -33,7 +33,7 @@ public class CaseClassifier {
     whereClause.append(
         String.format("WHERE collection_exercise_id='%s'", collectionExerciseId.toString()));
 
-    if (!StringUtils.isEmpty(classifiersClause)) {
+    if (StringUtils.hasText(classifiersClause)) {
       whereClause.append(" AND ").append(classifiersClause);
     }
 


### PR DESCRIPTION
# Motivation and Context
Spring Boot 2.5.2 deprecates StringUtils.isEmpty.

# What has changed
Used `StringUtils.hasText` instead.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/f7yh1qjL