### PR TITLE
Stop redacting sensitive keys & data when blanking

### DIFF
--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiverIT.java
@@ -103,6 +103,6 @@ public class UpdateSampleSensitiveReceiverIT {
 
     PayloadDTO actualPayload = objectMapper.readValue(event.getEventPayload(), PayloadDTO.class);
     assertThat(actualPayload.getUpdateSampleSensitive().getSampleSensitive())
-        .isEqualTo(Map.of("REDACTED", "REDACTED"));
+        .isEqualTo(Map.of("PHONE_NUMBER", "REDACTED"));
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/RedactHelperTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/RedactHelperTest.java
@@ -19,7 +19,7 @@ public class RedactHelperTest {
     Sample sampleDeepCopy = (Sample) RedactHelper.redact(sample);
 
     // THEN
-    assertThat(sampleDeepCopy.getSampleSensitive()).isEqualTo(Map.of("REDACTED", "REDACTED"));
+    assertThat(sampleDeepCopy.getSampleSensitive()).isEqualTo(Map.of("PHONE_NUMBER", "REDACTED"));
 
     // Extra check to make sure the original object wasn't accidentally mutated
     assertThat(sample.getSampleSensitive()).isEqualTo(Map.of("PHONE_NUMBER", "999999"));


### PR DESCRIPTION
# Motivation and Context
When we redact a value, we should be able to find out which value was changed or blanked out, but previously we were replacing ALL the sensitive data with "REDACTED" -> "REDACTED" which told us very little about what actually got changed.

# What has changed
Only redact values, not keys.

# How to test?
Use the wizarding ways.

# Links
Trello: https://trello.com/c/R1sxFecV