### PR TITLE
Simplify and improve leader election

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
@@ -21,7 +21,7 @@ public class ClusterLeaderManager {
   protected static final UUID LEADER_ID = UUID.fromString("e469807b-f2e2-47bd-acf6-74f8943ff3db");
 
   private final ClusterLeaderRepository clusterLeaderRepository;
-  private final ClusterLeaderManagerStartup clusterLeaderManagerStartup;
+  private final ClusterLeaderStartupManager clusterLeaderStartupManager;
 
   @Value("${scheduler.leaderDeathTimeout}")
   private int leaderDeathTimeout;
@@ -30,17 +30,17 @@ public class ClusterLeaderManager {
 
   public ClusterLeaderManager(
       ClusterLeaderRepository clusterLeaderRepository,
-      ClusterLeaderManagerStartup clusterLeaderManagerStartup)
+      ClusterLeaderStartupManager clusterLeaderStartupManager)
       throws UnknownHostException {
     this.clusterLeaderRepository = clusterLeaderRepository;
-    this.clusterLeaderManagerStartup = clusterLeaderManagerStartup;
+    this.clusterLeaderStartupManager = clusterLeaderStartupManager;
   }
 
   @Transactional(isolation = Isolation.REPEATABLE_READ)
   public boolean isThisHostClusterLeader() {
     synchronized (LEADER_ID) {
       try {
-        clusterLeaderManagerStartup.doStartupChecksAndAttemptToElectLeaderIfRequired(LEADER_ID);
+        clusterLeaderStartupManager.doStartupChecksAndAttemptToElectLeaderIfRequired(LEADER_ID);
       } catch (DataIntegrityViolationException dataIntegrityViolationException) {
         // Multiple processes had a dead-heat when trying to become leader, so let the losers fail
         return false;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
@@ -7,73 +7,44 @@ import java.net.UnknownHostException;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import uk.gov.ons.ssdc.caseprocessor.model.entity.ClusterLeader;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ClusterLeaderRepository;
 
 @Component
 public class ClusterLeaderManager {
   private static final Logger log = LoggerFactory.getLogger(ClusterLeaderManager.class);
-  private static final UUID LEADER_ID = UUID.fromString("e469807b-f2e2-47bd-acf6-74f8943ff3db");
-  private static final ReentrantLock lock = new ReentrantLock();
+  protected static final UUID LEADER_ID = UUID.fromString("e469807b-f2e2-47bd-acf6-74f8943ff3db");
 
   private final ClusterLeaderRepository clusterLeaderRepository;
+  private final ClusterLeaderManagerStartup clusterLeaderManagerStartup;
 
   @Value("${scheduler.leaderDeathTimeout}")
   private int leaderDeathTimeout;
 
   private String hostName = InetAddress.getLocalHost().getHostName();
 
-  public ClusterLeaderManager(ClusterLeaderRepository clusterLeaderRepository)
+  public ClusterLeaderManager(
+      ClusterLeaderRepository clusterLeaderRepository,
+      ClusterLeaderManagerStartup clusterLeaderManagerStartup)
       throws UnknownHostException {
     this.clusterLeaderRepository = clusterLeaderRepository;
+    this.clusterLeaderManagerStartup = clusterLeaderManagerStartup;
   }
 
   @Transactional(isolation = Isolation.REPEATABLE_READ)
   public boolean isThisHostClusterLeader() {
-    if (!clusterLeaderRepository.existsById(LEADER_ID)) {
-      boolean isLockAcquired;
-
-      // Obtain a lock, so that only one thread can possibly ever be attempting to declare that
-      // this host is the leader, by recording it in the database
+    synchronized (LEADER_ID) {
       try {
-        isLockAcquired = lock.tryLock(10, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        throw new RuntimeException("Failed to get lock before thread interrupted");
+        clusterLeaderManagerStartup.doStartupChecksAndAttemptToElectLeaderIfRequired(LEADER_ID);
+      } catch (DataIntegrityViolationException dataIntegrityViolationException) {
+        // Multiple processes had a dead-heat when trying to become leader, so let the losers fail
+        return false;
       }
-
-      // If we couldn't obtain a lock then we can't continue... throw an error and let spring retry
-      if (!isLockAcquired) {
-        throw new RuntimeException("Failed to get lock before timeout");
-      }
-
-      // Now we are locked, record that this host is the cluster leader in the database
-      ClusterLeader clusterLeader = new ClusterLeader();
-      clusterLeader.setId(LEADER_ID);
-      clusterLeader.setHostName(hostName);
-      clusterLeader.setHostLastSeenAliveAt(OffsetDateTime.now());
-      clusterLeaderRepository.saveAndFlush(clusterLeader);
-
-      // Finally, only release the lock once the transaction has been committed (or rolled back)
-      if (TransactionSynchronizationManager.isSynchronizationActive()) {
-        TransactionSynchronizationManager.registerSynchronization(
-            new TransactionSynchronization() {
-              @Override
-              public void afterCompletion(int status) {
-                lock.unlock();
-              }
-            });
-      }
-
-      log.with("hostName", hostName)
-          .debug("No leader existed in DB, so this host is attempting to become leader");
     }
 
     Optional<ClusterLeader> lockedClusterLeaderOpt =

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManager.java
@@ -18,7 +18,7 @@ import uk.gov.ons.ssdc.caseprocessor.model.repository.ClusterLeaderRepository;
 @Component
 public class ClusterLeaderManager {
   private static final Logger log = LoggerFactory.getLogger(ClusterLeaderManager.class);
-  protected static final UUID LEADER_ID = UUID.fromString("e469807b-f2e2-47bd-acf6-74f8943ff3db");
+  private static final UUID LEADER_ID = UUID.fromString("e469807b-f2e2-47bd-acf6-74f8943ff3db");
 
   private final ClusterLeaderRepository clusterLeaderRepository;
   private final ClusterLeaderStartupManager clusterLeaderStartupManager;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ssdc.caseprocessor.schedule;
 
-
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.net.InetAddress;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
@@ -27,17 +27,19 @@ public class ClusterLeaderManagerStartup {
 
   @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)
   public void doStartupChecksAndAttemptToElectLeaderIfRequired(UUID leaderId) {
-    if (!clusterLeaderRepository.existsById(leaderId)) {
-      // We are starting up for the first time!
-      // Record that this host is the cluster leader in the database
-      ClusterLeader clusterLeader = new ClusterLeader();
-      clusterLeader.setId(leaderId);
-      clusterLeader.setHostName(hostName);
-      clusterLeader.setHostLastSeenAliveAt(OffsetDateTime.now());
-      clusterLeaderRepository.saveAndFlush(clusterLeader);
-
-      log.with("hostName", hostName)
-          .debug("No leader existed in DB, so this host is attempting to become leader");
+    if (clusterLeaderRepository.existsById(leaderId)) {
+      return; // We are not staring up for the first time... nothing to do here
     }
+
+    // We ARE starting up for the first time!
+    // Record that this host is the cluster leader in the database
+    ClusterLeader clusterLeader = new ClusterLeader();
+    clusterLeader.setId(leaderId);
+    clusterLeader.setHostName(hostName);
+    clusterLeader.setHostLastSeenAliveAt(OffsetDateTime.now());
+    clusterLeaderRepository.saveAndFlush(clusterLeader);
+
+    log.with("hostName", hostName)
+        .debug("No leader existed in DB, so this host is attempting to become leader");
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
@@ -28,7 +28,7 @@ public class ClusterLeaderManagerStartup {
   @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)
   public void doStartupChecksAndAttemptToElectLeaderIfRequired(UUID leaderId) {
     if (clusterLeaderRepository.existsById(leaderId)) {
-      return; // We are not staring up for the first time... nothing to do here
+      return; // We are not starting up for the first time... nothing to do here
     }
 
     // We ARE starting up for the first time!

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderManagerStartup.java
@@ -1,0 +1,44 @@
+package uk.gov.ons.ssdc.caseprocessor.schedule;
+
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.ssdc.caseprocessor.model.entity.ClusterLeader;
+import uk.gov.ons.ssdc.caseprocessor.model.repository.ClusterLeaderRepository;
+
+@Component
+public class ClusterLeaderManagerStartup {
+  private static final Logger log = LoggerFactory.getLogger(ClusterLeaderManagerStartup.class);
+  private final ClusterLeaderRepository clusterLeaderRepository;
+
+  private String hostName = InetAddress.getLocalHost().getHostName();
+
+  public ClusterLeaderManagerStartup(ClusterLeaderRepository clusterLeaderRepository)
+      throws UnknownHostException {
+    this.clusterLeaderRepository = clusterLeaderRepository;
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ)
+  public void doStartupChecksAndAttemptToElectLeaderIfRequired(UUID leaderId) {
+    if (!clusterLeaderRepository.existsById(leaderId)) {
+      // We are starting up for the first time!
+      // Record that this host is the cluster leader in the database
+      ClusterLeader clusterLeader = new ClusterLeader();
+      clusterLeader.setId(leaderId);
+      clusterLeader.setHostName(hostName);
+      clusterLeader.setHostLastSeenAliveAt(OffsetDateTime.now());
+      clusterLeaderRepository.saveAndFlush(clusterLeader);
+
+      log.with("hostName", hostName)
+          .debug("No leader existed in DB, so this host is attempting to become leader");
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderStartupManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ClusterLeaderStartupManager.java
@@ -14,13 +14,13 @@ import uk.gov.ons.ssdc.caseprocessor.model.entity.ClusterLeader;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ClusterLeaderRepository;
 
 @Component
-public class ClusterLeaderManagerStartup {
-  private static final Logger log = LoggerFactory.getLogger(ClusterLeaderManagerStartup.class);
+public class ClusterLeaderStartupManager {
+  private static final Logger log = LoggerFactory.getLogger(ClusterLeaderStartupManager.class);
   private final ClusterLeaderRepository clusterLeaderRepository;
 
   private String hostName = InetAddress.getLocalHost().getHostName();
 
-  public ClusterLeaderManagerStartup(ClusterLeaderRepository clusterLeaderRepository)
+  public ClusterLeaderStartupManager(ClusterLeaderRepository clusterLeaderRepository)
       throws UnknownHostException {
     this.clusterLeaderRepository = clusterLeaderRepository;
   }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/DeleteDataHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/DeleteDataHelper.java
@@ -8,6 +8,7 @@ import uk.gov.ons.ssdc.caseprocessor.model.repository.ActionRuleRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ActionRuleSurveyPrintTemplateRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.CaseRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.CaseToProcessRepository;
+import uk.gov.ons.ssdc.caseprocessor.model.repository.ClusterLeaderRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.CollectionExerciseRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.EventRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.FulfilmentNextTriggerRepository;
@@ -37,6 +38,7 @@ public class DeleteDataHelper {
 
   @Autowired private ActionRuleRepository actionRuleRepository;
   @Autowired private CaseToProcessRepository caseToProcessRepository;
+  @Autowired private ClusterLeaderRepository clusterLeaderRepository;
 
   @Transactional
   public void deleteAllData() {
@@ -52,5 +54,6 @@ public class DeleteDataHelper {
     actionRuleSurveyPrintTemplateRepository.deleteAllInBatch();
     printTemplateRepository.deleteAllInBatch();
     surveyRepository.deleteAllInBatch();
+    clusterLeaderRepository.deleteAllInBatch();
   }
 }


### PR DESCRIPTION
# Motivation and Context
Leader election was spitting out errors into the logs, and I suspect that it might be the reason why we have an integration test which fails occasionally.

# What has changed
Got rid of the complex locking in favour of much simpler locking. Handled the dead heat in a more elegant and explicit way. Generally simplified and improved.

# How to test?
Ensure that the table `cluster_leader` is empty, then start Case Processor up. You should see zero errors on startup (before you would have seen some kind of key violation occasionally).

# Links
Trello: https://trello.com/c/68HFsjax