### PR TITLE
Fix unreliable HealthCheckIT

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/healthcheck/HeathCheck.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/healthcheck/HeathCheck.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -27,7 +27,7 @@ public class HeathCheck {
     clusterLeaderManager.leaderKeepAlive();
 
     Path path = Paths.get(fileName);
-    LocalDateTime now = LocalDateTime.now();
+    OffsetDateTime now = OffsetDateTime.now();
 
     try (BufferedWriter writer = Files.newBufferedWriter(path)) {
       writer.write(now.toString());

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/healthcheck/HeathCheckIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/healthcheck/HeathCheckIT.java
@@ -1,13 +1,13 @@
 package uk.gov.ons.ssdc.caseprocessor.healthcheck;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,9 +28,10 @@ public class HeathCheckIT {
 
     try (BufferedReader bufferedReader = Files.newBufferedReader(path)) {
       String fileLine = bufferedReader.readLine();
-      String now = LocalDateTime.now().toString();
+      OffsetDateTime healthCheckTimeStamp = OffsetDateTime.parse(fileLine);
 
-      assertEquals(now.substring(0, 15), fileLine.substring(0, 15));
+      assertThat(OffsetDateTime.now().toEpochSecond() - healthCheckTimeStamp.toEpochSecond())
+          .isLessThan(30);
     }
   }
 }


### PR DESCRIPTION
# Motivation and Context
HealthCheckIT was failing quite frequently... especially if ever run on the change of hour.

# What has changed
Fixed it to check the time difference, not by looking at the first n characters of the date as an ISO string.

# How to test?
Run the IT.

# Links
Trello: https://trello.com/c/cDKl8nne