### PR TITLE
Action Rule Performance Improvements

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/MessageSender.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/MessageSender.java
@@ -20,6 +20,6 @@ public class MessageSender {
     messageToSend.setDestinationTopic(destinationTopic);
     messageToSend.setMessageBody(JsonHelper.convertObjectToJson(message));
 
-    messageToSendRepository.saveAndFlush(messageToSend);
+    messageToSendRepository.save(messageToSend);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
@@ -28,7 +28,7 @@ public class UacService {
   }
 
   public UacQidLink saveAndEmitUacUpdatedEvent(UacQidLink uacQidLink) {
-    UacQidLink savedUacQidLink = uacQidLinkRepository.saveAndFlush(uacQidLink);
+    UacQidLink savedUacQidLink = uacQidLinkRepository.save(uacQidLink);
 
     EventDTO eventDTO = EventHelper.createEventDTO(EventTypeDTO.UAC_UPDATED);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   task:
     scheduling:
       pool:
-        size: 10
+        size: 30
 
   datasource:
     url: jdbc:postgresql://localhost:6432/postgres
@@ -24,6 +24,8 @@ spring:
       hibernate:
         default_schema: casev3
         jdbc:
+          batch_size: 1000
+          order_inserts: true
           lob:
             non_contextual_creation: true
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ChunkProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ChunkProcessorTest.java
@@ -43,7 +43,7 @@ public class ChunkProcessorTest {
     // Then
     verify(caseToProcessRepository).findChunkToProcess(eq(chunkSize));
     verify(caseToProcessProcessor).process(eq(caseToProcess));
-    verify(caseToProcessRepository).delete(eq(caseToProcess));
+    verify(caseToProcessRepository).deleteAllInBatch(eq(List.of(caseToProcess)));
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
The performance of action rules had degraded quite severely since introducing Pub/Sub.

# What has changed
Used JDBC batching in Hibernate and judicious use of `save` rather than `saveAndFlush` in batched parts of the code, to reduce round-trips to the database.

# How to test?
Should be zero regression. Has already been performance tested as part of this ticket: https://trello.com/c/uIZy4dQc

# Links
Trello: https://trello.com/c/1wP9AbPA