### PR TITLE
Use shared project for shared pubsub topics and subscriptions

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/Application.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/Application.java
@@ -6,10 +6,8 @@ import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfigura
 import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubReactiveAutoConfiguration;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 
-@SpringBootApplication(exclude = {
-    GcpPubSubAutoConfiguration.class,
-    GcpPubSubReactiveAutoConfiguration.class})
-//@SpringBootApplication
+@SpringBootApplication(
+    exclude = {GcpPubSubAutoConfiguration.class, GcpPubSubReactiveAutoConfiguration.class})
 @IntegrationComponentScan
 public class Application {
   public static void main(String[] args) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/Application.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/Application.java
@@ -2,9 +2,14 @@ package uk.gov.ons.ssdc.caseprocessor;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubReactiveAutoConfiguration;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {
+    GcpPubSubAutoConfiguration.class,
+    GcpPubSubReactiveAutoConfiguration.class})
+//@SpringBootApplication
 @IntegrationComponentScan
 public class Application {
   public static void main(String[] args) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -1,15 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.config;
 
-import com.google.api.gax.grpc.GrpcTransportChannel;
-import com.google.api.gax.rpc.FixedTransportChannelProvider;
-import com.google.api.gax.rpc.TransportChannelProvider;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
-import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
-import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
-import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,14 +15,14 @@ public class AppConfig {
     return new SimplePubSubMessageConverter();
   }
 
-//  @Bean
-//  public TransportChannelProvider transportChannelProvider() {
-//    String hostport = System.getenv("PUBSUB_EMULATOR_HOST");
-//    ManagedChannel channel = ManagedChannelBuilder.forTarget(hostport).usePlaintext().build();
-//    TransportChannelProvider channelProvider =
-//        FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
-//    return channelProvider;
-//  }
+  //  @Bean
+  //  public TransportChannelProvider transportChannelProvider() {
+  //    String hostport = System.getenv("PUBSUB_EMULATOR_HOST");
+  //    ManagedChannel channel = ManagedChannelBuilder.forTarget(hostport).usePlaintext().build();
+  //    TransportChannelProvider channelProvider =
+  //        FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+  //    return channelProvider;
+  //  }
 
   @PostConstruct
   public void init() {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -1,5 +1,10 @@
 package uk.gov.ons.ssdc.caseprocessor.config;
 
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
@@ -14,19 +19,18 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 public class AppConfig {
   @Bean
-  public PubSubTemplate pubSubTemplate(
-      PublisherFactory publisherFactory,
-      SubscriberFactory subscriberFactory,
-      SimplePubSubMessageConverter simplePubSubMessageConverter) {
-    PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
-    pubSubTemplate.setMessageConverter(simplePubSubMessageConverter);
-    return pubSubTemplate;
-  }
-
-  @Bean
   public SimplePubSubMessageConverter messageConverter() {
     return new SimplePubSubMessageConverter();
   }
+
+//  @Bean
+//  public TransportChannelProvider transportChannelProvider() {
+//    String hostport = System.getenv("PUBSUB_EMULATOR_HOST");
+//    ManagedChannel channel = ManagedChannelBuilder.forTarget(hostport).usePlaintext().build();
+//    TransportChannelProvider channelProvider =
+//        FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+//    return channelProvider;
+//  }
 
   @PostConstruct
   public void init() {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -15,15 +15,6 @@ public class AppConfig {
     return new SimplePubSubMessageConverter();
   }
 
-  //  @Bean
-  //  public TransportChannelProvider transportChannelProvider() {
-  //    String hostport = System.getenv("PUBSUB_EMULATOR_HOST");
-  //    ManagedChannel channel = ManagedChannelBuilder.forTarget(hostport).usePlaintext().build();
-  //    TransportChannelProvider channelProvider =
-  //        FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
-  //    return channelProvider;
-  //  }
-
   @PostConstruct
   public void init() {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
@@ -102,67 +102,67 @@ public class MessageConsumerConfig {
 
   @Bean
   public PubSubInboundChannelAdapter inboundSamples(
-      @Qualifier("sampleInputChannel") MessageChannel channel, PubSubTemplate pubSubTemplate) {
+      @Qualifier("sampleInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, sampleSubscription);
   }
 
   @Bean
   public PubSubInboundChannelAdapter receiptInbound(
-      @Qualifier("receiptInputChannel") MessageChannel channel, PubSubTemplate pubSubTemplate) {
+      @Qualifier("receiptInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, receiptSubscription);
   }
 
   @Bean
   public PubSubInboundChannelAdapter refusalInbound(
-      @Qualifier("refusalInputChannel") MessageChannel channel, PubSubTemplate pubSubTemplate) {
+      @Qualifier("refusalInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, refusalSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter invalidCaseInbound(
-      @Qualifier("invalidCaseInputChannel") MessageChannel channel, PubSubTemplate pubSubTemplate) {
+      @Qualifier("invalidCaseInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, invalidCaseSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter surveyLaunchedInbound(
       @Qualifier("surveyLaunchInputChannel") MessageChannel channel,
-      PubSubTemplate pubSubTemplate) {
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, surveyLaunchSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter uacAuthenticationInbound(
       @Qualifier("uacAuthenticationInputChannel") MessageChannel channel,
-      PubSubTemplate pubSubTemplate) {
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, uacAuthenticationSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter fulfilmentInbound(
       @Qualifier("printFulfilmentInputChannel") MessageChannel channel,
-      PubSubTemplate pubSubTemplate) {
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, printFulfilmentSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter telephoneCaptureInbound(
       @Qualifier("telephoneCaptureInputChannel") MessageChannel channel,
-      PubSubTemplate pubSubTemplate) {
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, telephoneCaptureSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter deactivateUacInbound(
       @Qualifier("deactivateUacInputChannel") MessageChannel channel,
-      PubSubTemplate pubSubTemplate) {
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, deactivateUacSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter updateSampleSensitiveInbound(
       @Qualifier("updateSampleSensitiveInputChannel") MessageChannel channel,
-      PubSubTemplate pubSubTemplate) {
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, updateSampleSensitiveSubscription);
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
@@ -102,25 +102,29 @@ public class MessageConsumerConfig {
 
   @Bean
   public PubSubInboundChannelAdapter inboundSamples(
-      @Qualifier("sampleInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
+      @Qualifier("sampleInputChannel") MessageChannel channel,
+      @Qualifier("ourProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, sampleSubscription);
   }
 
   @Bean
   public PubSubInboundChannelAdapter receiptInbound(
-      @Qualifier("receiptInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
+      @Qualifier("receiptInputChannel") MessageChannel channel,
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, receiptSubscription);
   }
 
   @Bean
   public PubSubInboundChannelAdapter refusalInbound(
-      @Qualifier("refusalInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
+      @Qualifier("refusalInputChannel") MessageChannel channel,
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, refusalSubscription);
   }
 
   @Bean
   PubSubInboundChannelAdapter invalidCaseInbound(
-      @Qualifier("invalidCaseInputChannel") MessageChannel channel, @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
+      @Qualifier("invalidCaseInputChannel") MessageChannel channel,
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, invalidCaseSubscription);
   }
 
@@ -148,7 +152,7 @@ public class MessageConsumerConfig {
   @Bean
   PubSubInboundChannelAdapter telephoneCaptureInbound(
       @Qualifier("telephoneCaptureInputChannel") MessageChannel channel,
-      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
+      @Qualifier("ourProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     return makeAdapter(channel, pubSubTemplate, telephoneCaptureSubscription);
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
@@ -19,74 +19,82 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OurProjectPubsubConfig {
-//  @Value("${queueconfig.shared-pubsub-project}")
-//  private String sharedPubsubProject;
-//
-//  private final GcpPubSubProperties gcpPubSubProperties;
-//
-//  public OurProjectPubsubConfig(
-//      GcpPubSubProperties gcpPubSubProperties) {
-//    this.gcpPubSubProperties = gcpPubSubProperties;
-//  }
-//
-//  @Bean("sharedProjectPubSubSubscriberTemplate")
-//  public PubSubSubscriberTemplate pubSubSubscriberTemplate(
-//      @Qualifier("sharedProjectSubscriberFactory") SubscriberFactory subscriberFactory) {
-//    return new PubSubSubscriberTemplate(subscriberFactory);
-//  }
-//
-//  @Bean("sharedProjectPubSubPublisherTemplate")
-//  public PubSubPublisherTemplate pubSubPublisherTemplate(
-//      @Qualifier("sharedProjectPublisherFactory") PublisherFactory publisherFactory) {
-//    return new PubSubPublisherTemplate(publisherFactory);
-//  }
-//
-//  @Bean("sharedProjectPublisherFactory")
-//  public DefaultPublisherFactory publisherFactory(CredentialsProvider credentialsProvider,
-//      @Qualifier("publisherTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
-//    final DefaultPublisherFactory defaultPublisherFactory = new DefaultPublisherFactory(() -> sharedPubsubProject);
-//
-//    if (gcpPubSubProperties.getEmulatorHost() == null
-//        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
-//      defaultPublisherFactory.setCredentialsProvider(credentialsProvider);
-//    } else {
-//      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
-//      // (because it would also be used for the other components), we have to create one here
-//      // for this particular case.
-//      defaultPublisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
-//    }
-//
-//    defaultPublisherFactory.setChannelProvider(transportChannelProvider);
-//    return defaultPublisherFactory;
-//  }
-//
-//  @Bean("sharedProjectSubscriberFactory")
-//  public DefaultSubscriberFactory subscriberFactory(CredentialsProvider credentialsProvider,
-//      @Qualifier("subscriberTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
-//    final DefaultSubscriberFactory defaultSubscriberFactory = new DefaultSubscriberFactory(() -> sharedPubsubProject);
-//
-//    if (gcpPubSubProperties.getEmulatorHost() == null
-//        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
-//      defaultSubscriberFactory.setCredentialsProvider(credentialsProvider);
-//    } else {
-//      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
-//      // (because it would also be used for the other components), we have to create one here
-//      // for this particular case.
-//      defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
-//    }
-//
-//    defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
-//    defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
-//    return defaultSubscriberFactory;
-//  }
-//
-//  @Bean(name = "sharedProjectPubSubTemplate")
-//  public PubSubTemplate pubSubTemplate(
-//      PubSubPublisherTemplate pubSubPublisherTemplate,
-//      PubSubSubscriberTemplate pubSubSubscriberTemplate,
-//      SimplePubSubMessageConverter simplePubSubMessageConverter) {
-//    PubSubTemplate pubSubTemplate = new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
-//    pubSubTemplate.setMessageConverter(simplePubSubMessageConverter);
-//    return pubSubTemplate;
-//  }
+  @Value("${queueconfig.our-pubsub-project}")
+  private String ourPubsubProject;
+
+  private final GcpPubSubProperties gcpPubSubProperties;
+
+  public OurProjectPubsubConfig(GcpPubSubProperties gcpPubSubProperties) {
+    this.gcpPubSubProperties = gcpPubSubProperties;
+  }
+
+  @Bean("ourProjectPubSubSubscriberTemplate")
+  public PubSubSubscriberTemplate pubSubSubscriberTemplate(
+      @Qualifier("ourProjectSubscriberFactory") SubscriberFactory subscriberFactory) {
+    return new PubSubSubscriberTemplate(subscriberFactory);
+  }
+
+  @Bean("ourProjectPubSubPublisherTemplate")
+  public PubSubPublisherTemplate pubSubPublisherTemplate(
+      @Qualifier("ourProjectPublisherFactory") PublisherFactory publisherFactory) {
+    return new PubSubPublisherTemplate(publisherFactory);
+  }
+
+  @Bean("ourProjectPublisherFactory")
+  public DefaultPublisherFactory publisherFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("publisherTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultPublisherFactory defaultPublisherFactory =
+        new DefaultPublisherFactory(() -> ourPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultPublisherFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultPublisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultPublisherFactory.setChannelProvider(transportChannelProvider);
+    return defaultPublisherFactory;
+  }
+
+  @Bean("ourProjectSubscriberFactory")
+  public DefaultSubscriberFactory subscriberFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("subscriberTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultSubscriberFactory defaultSubscriberFactory =
+        new DefaultSubscriberFactory(() -> ourPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultSubscriberFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
+    return defaultSubscriberFactory;
+  }
+
+  @Bean(name = "ourProjectPubSubTemplate")
+  public PubSubTemplate pubSubTemplate(
+      @Qualifier("ourProjectPubSubPublisherTemplate")
+          PubSubPublisherTemplate pubSubPublisherTemplate,
+      @Qualifier("ourProjectPubSubSubscriberTemplate")
+          PubSubSubscriberTemplate pubSubSubscriberTemplate,
+      SimplePubSubMessageConverter simplePubSubMessageConverter) {
+    PubSubTemplate pubSubTemplate =
+        new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
+    pubSubTemplate.setMessageConverter(simplePubSubMessageConverter);
+    return pubSubTemplate;
+  }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
@@ -1,0 +1,92 @@
+package uk.gov.ons.ssdc.caseprocessor.config;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubProperties;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
+import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OurProjectPubsubConfig {
+//  @Value("${queueconfig.shared-pubsub-project}")
+//  private String sharedPubsubProject;
+//
+//  private final GcpPubSubProperties gcpPubSubProperties;
+//
+//  public OurProjectPubsubConfig(
+//      GcpPubSubProperties gcpPubSubProperties) {
+//    this.gcpPubSubProperties = gcpPubSubProperties;
+//  }
+//
+//  @Bean("sharedProjectPubSubSubscriberTemplate")
+//  public PubSubSubscriberTemplate pubSubSubscriberTemplate(
+//      @Qualifier("sharedProjectSubscriberFactory") SubscriberFactory subscriberFactory) {
+//    return new PubSubSubscriberTemplate(subscriberFactory);
+//  }
+//
+//  @Bean("sharedProjectPubSubPublisherTemplate")
+//  public PubSubPublisherTemplate pubSubPublisherTemplate(
+//      @Qualifier("sharedProjectPublisherFactory") PublisherFactory publisherFactory) {
+//    return new PubSubPublisherTemplate(publisherFactory);
+//  }
+//
+//  @Bean("sharedProjectPublisherFactory")
+//  public DefaultPublisherFactory publisherFactory(CredentialsProvider credentialsProvider,
+//      @Qualifier("publisherTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
+//    final DefaultPublisherFactory defaultPublisherFactory = new DefaultPublisherFactory(() -> sharedPubsubProject);
+//
+//    if (gcpPubSubProperties.getEmulatorHost() == null
+//        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+//      defaultPublisherFactory.setCredentialsProvider(credentialsProvider);
+//    } else {
+//      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+//      // (because it would also be used for the other components), we have to create one here
+//      // for this particular case.
+//      defaultPublisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
+//    }
+//
+//    defaultPublisherFactory.setChannelProvider(transportChannelProvider);
+//    return defaultPublisherFactory;
+//  }
+//
+//  @Bean("sharedProjectSubscriberFactory")
+//  public DefaultSubscriberFactory subscriberFactory(CredentialsProvider credentialsProvider,
+//      @Qualifier("subscriberTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
+//    final DefaultSubscriberFactory defaultSubscriberFactory = new DefaultSubscriberFactory(() -> sharedPubsubProject);
+//
+//    if (gcpPubSubProperties.getEmulatorHost() == null
+//        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+//      defaultSubscriberFactory.setCredentialsProvider(credentialsProvider);
+//    } else {
+//      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+//      // (because it would also be used for the other components), we have to create one here
+//      // for this particular case.
+//      defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+//    }
+//
+//    defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+//    defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
+//    return defaultSubscriberFactory;
+//  }
+//
+//  @Bean(name = "sharedProjectPubSubTemplate")
+//  public PubSubTemplate pubSubTemplate(
+//      PubSubPublisherTemplate pubSubPublisherTemplate,
+//      PubSubSubscriberTemplate pubSubSubscriberTemplate,
+//      SimplePubSubMessageConverter simplePubSubMessageConverter) {
+//    PubSubTemplate pubSubTemplate = new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
+//    pubSubTemplate.setMessageConverter(simplePubSubMessageConverter);
+//    return pubSubTemplate;
+//  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
@@ -80,7 +80,6 @@ public class OurProjectPubsubConfig {
       defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
     }
 
-    defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
     defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
     return defaultSubscriberFactory;
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/OurProjectPubsubConfig.java
@@ -41,47 +41,46 @@ public class OurProjectPubsubConfig {
   }
 
   @Bean("ourProjectPublisherFactory")
-  public DefaultPublisherFactory publisherFactory(
+  public PublisherFactory publisherFactory(
       CredentialsProvider credentialsProvider,
       @Qualifier("publisherTransportChannelProvider")
           TransportChannelProvider transportChannelProvider) {
-    final DefaultPublisherFactory defaultPublisherFactory =
-        new DefaultPublisherFactory(() -> ourPubsubProject);
+    DefaultPublisherFactory publisherFactory = new DefaultPublisherFactory(() -> ourPubsubProject);
 
     if (gcpPubSubProperties.getEmulatorHost() == null
         || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
-      defaultPublisherFactory.setCredentialsProvider(credentialsProvider);
+      publisherFactory.setCredentialsProvider(credentialsProvider);
     } else {
       // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
       // (because it would also be used for the other components), we have to create one here
       // for this particular case.
-      defaultPublisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
+      publisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
     }
 
-    defaultPublisherFactory.setChannelProvider(transportChannelProvider);
-    return defaultPublisherFactory;
+    publisherFactory.setChannelProvider(transportChannelProvider);
+    return publisherFactory;
   }
 
   @Bean("ourProjectSubscriberFactory")
-  public DefaultSubscriberFactory subscriberFactory(
+  public SubscriberFactory subscriberFactory(
       CredentialsProvider credentialsProvider,
       @Qualifier("subscriberTransportChannelProvider")
           TransportChannelProvider transportChannelProvider) {
-    final DefaultSubscriberFactory defaultSubscriberFactory =
+    DefaultSubscriberFactory subscriberFactory =
         new DefaultSubscriberFactory(() -> ourPubsubProject);
 
     if (gcpPubSubProperties.getEmulatorHost() == null
         || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
-      defaultSubscriberFactory.setCredentialsProvider(credentialsProvider);
+      subscriberFactory.setCredentialsProvider(credentialsProvider);
     } else {
       // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
       // (because it would also be used for the other components), we have to create one here
       // for this particular case.
-      defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+      subscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
     }
 
-    defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
-    return defaultSubscriberFactory;
+    subscriberFactory.setChannelProvider(transportChannelProvider);
+    return subscriberFactory;
   }
 
   @Bean(name = "ourProjectPubSubTemplate")

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/SharedProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/SharedProjectPubsubConfig.java
@@ -1,0 +1,92 @@
+package uk.gov.ons.ssdc.caseprocessor.config;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubProperties;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
+import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SharedProjectPubsubConfig {
+  @Value("${queueconfig.shared-pubsub-project}")
+  private String sharedPubsubProject;
+
+  private final GcpPubSubProperties gcpPubSubProperties;
+
+  public SharedProjectPubsubConfig(
+      GcpPubSubProperties gcpPubSubProperties) {
+    this.gcpPubSubProperties = gcpPubSubProperties;
+  }
+
+  @Bean("sharedProjectPubSubSubscriberTemplate")
+  public PubSubSubscriberTemplate pubSubSubscriberTemplate(
+      @Qualifier("sharedProjectSubscriberFactory") SubscriberFactory subscriberFactory) {
+    return new PubSubSubscriberTemplate(subscriberFactory);
+  }
+
+  @Bean("sharedProjectPubSubPublisherTemplate")
+  public PubSubPublisherTemplate pubSubPublisherTemplate(
+      @Qualifier("sharedProjectPublisherFactory") PublisherFactory publisherFactory) {
+    return new PubSubPublisherTemplate(publisherFactory);
+  }
+
+  @Bean("sharedProjectPublisherFactory")
+  public DefaultPublisherFactory publisherFactory(CredentialsProvider credentialsProvider,
+      @Qualifier("publisherTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
+    final DefaultPublisherFactory defaultPublisherFactory = new DefaultPublisherFactory(() -> sharedPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultPublisherFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultPublisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultPublisherFactory.setChannelProvider(transportChannelProvider);
+    return defaultPublisherFactory;
+  }
+
+  @Bean("sharedProjectSubscriberFactory")
+  public DefaultSubscriberFactory subscriberFactory(CredentialsProvider credentialsProvider,
+      @Qualifier("subscriberTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
+    final DefaultSubscriberFactory defaultSubscriberFactory = new DefaultSubscriberFactory(() -> sharedPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultSubscriberFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
+    return defaultSubscriberFactory;
+  }
+
+  @Bean(name = "sharedProjectPubSubTemplate")
+  public PubSubTemplate pubSubTemplate(
+      PubSubPublisherTemplate pubSubPublisherTemplate,
+      PubSubSubscriberTemplate pubSubSubscriberTemplate,
+      SimplePubSubMessageConverter simplePubSubMessageConverter) {
+    PubSubTemplate pubSubTemplate = new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
+    pubSubTemplate.setMessageConverter(simplePubSubMessageConverter);
+    return pubSubTemplate;
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/SharedProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/SharedProjectPubsubConfig.java
@@ -24,8 +24,7 @@ public class SharedProjectPubsubConfig {
 
   private final GcpPubSubProperties gcpPubSubProperties;
 
-  public SharedProjectPubsubConfig(
-      GcpPubSubProperties gcpPubSubProperties) {
+  public SharedProjectPubsubConfig(GcpPubSubProperties gcpPubSubProperties) {
     this.gcpPubSubProperties = gcpPubSubProperties;
   }
 
@@ -42,9 +41,12 @@ public class SharedProjectPubsubConfig {
   }
 
   @Bean("sharedProjectPublisherFactory")
-  public DefaultPublisherFactory publisherFactory(CredentialsProvider credentialsProvider,
-      @Qualifier("publisherTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
-    final DefaultPublisherFactory defaultPublisherFactory = new DefaultPublisherFactory(() -> sharedPubsubProject);
+  public DefaultPublisherFactory publisherFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("publisherTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultPublisherFactory defaultPublisherFactory =
+        new DefaultPublisherFactory(() -> sharedPubsubProject);
 
     if (gcpPubSubProperties.getEmulatorHost() == null
         || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
@@ -61,9 +63,12 @@ public class SharedProjectPubsubConfig {
   }
 
   @Bean("sharedProjectSubscriberFactory")
-  public DefaultSubscriberFactory subscriberFactory(CredentialsProvider credentialsProvider,
-      @Qualifier("subscriberTransportChannelProvider") TransportChannelProvider transportChannelProvider) {
-    final DefaultSubscriberFactory defaultSubscriberFactory = new DefaultSubscriberFactory(() -> sharedPubsubProject);
+  public DefaultSubscriberFactory subscriberFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("subscriberTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultSubscriberFactory defaultSubscriberFactory =
+        new DefaultSubscriberFactory(() -> sharedPubsubProject);
 
     if (gcpPubSubProperties.getEmulatorHost() == null
         || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
@@ -82,10 +87,13 @@ public class SharedProjectPubsubConfig {
 
   @Bean(name = "sharedProjectPubSubTemplate")
   public PubSubTemplate pubSubTemplate(
-      PubSubPublisherTemplate pubSubPublisherTemplate,
-      PubSubSubscriberTemplate pubSubSubscriberTemplate,
+      @Qualifier("sharedProjectPubSubPublisherTemplate")
+          PubSubPublisherTemplate pubSubPublisherTemplate,
+      @Qualifier("sharedProjectPubSubSubscriberTemplate")
+          PubSubSubscriberTemplate pubSubSubscriberTemplate,
       SimplePubSubMessageConverter simplePubSubMessageConverter) {
-    PubSubTemplate pubSubTemplate = new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
+    PubSubTemplate pubSubTemplate =
+        new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
     pubSubTemplate.setMessageConverter(simplePubSubMessageConverter);
     return pubSubTemplate;
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/MessageSender.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/MessageSender.java
@@ -14,12 +14,17 @@ public class MessageSender {
     this.messageToSendRepository = messageToSendRepository;
   }
 
-  public void sendMessage(String destinationTopic, Object message) {
+  public void sendMessage(String destinationTopic, Object message, boolean sendToOurProject) {
     MessageToSend messageToSend = new MessageToSend();
     messageToSend.setId(UUID.randomUUID());
     messageToSend.setDestinationTopic(destinationTopic);
     messageToSend.setMessageBody(JsonHelper.convertObjectToJson(message));
+    messageToSend.setSendToOurProject(sendToOurProject);
 
     messageToSendRepository.save(messageToSend);
+  }
+
+  public void sendMessage(String destinationTopic, Object message) {
+    sendMessage(destinationTopic, message, false);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/MessageToSend.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/MessageToSend.java
@@ -15,6 +15,8 @@ public class MessageToSend {
 
   @Column private String destinationTopic;
 
+  @Column private boolean sendToOurProject;
+
   @Lob
   @Type(type = "org.hibernate.type.BinaryType")
   @Column

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/MessageToSendSender.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/MessageToSendSender.java
@@ -5,6 +5,7 @@ import com.google.pubsub.v1.PubsubMessage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.stereotype.Component;
@@ -18,7 +19,7 @@ public class MessageToSendSender {
   @Value("${queueconfig.publishtimeout}")
   private int publishTimeout;
 
-  public MessageToSendSender(PubSubTemplate pubSubTemplate) {
+  public MessageToSendSender(@Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     this.pubSubTemplate = pubSubTemplate;
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/MessageToSendSender.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/MessageToSendSender.java
@@ -19,7 +19,8 @@ public class MessageToSendSender {
   @Value("${queueconfig.publishtimeout}")
   private int publishTimeout;
 
-  public MessageToSendSender(@Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
+  public MessageToSendSender(
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     this.pubSubTemplate = pubSubTemplate;
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
@@ -100,7 +100,7 @@ public class PrintProcessor {
     printRow.setPackCode(packCode);
     printRow.setPrintSupplier(printSupplier);
 
-    messageSender.sendMessage(printTopic, printRow);
+    messageSender.sendMessage(printTopic, printRow, true);
 
     eventLogger.logCaseEvent(
         caze,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ queueconfig:
   deactivate-uac-topic: event_deactivate-uac
   publishtimeout: 30  # In seconds
   our-pubsub-project: our-project
-  shared-pubsub-project: project
+  shared-pubsub-project: shared-project
 
 healthcheck:
   frequency: 15000 #milliseconds

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,12 +12,6 @@ spring:
     hikari:
       maximumPoolSize: 50
 
-  cloud:
-    gcp:
-      pubsub:
-        emulator-host: localhost:8538
-        project-id: project
-
   sql:
     init:
       mode: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,12 @@ spring:
     hikari:
       maximumPoolSize: 50
 
+  cloud:
+    gcp:
+      pubsub:
+        emulator-host: localhost:8538
+        project-id: project
+
   sql:
     init:
       mode: always
@@ -29,7 +35,6 @@ spring:
           lob:
             non_contextual_creation: true
 
-
 queueconfig:
   telephone-capture-subscription: rm-internal-telephone-capture_case-processor
   sample-subscription: rm-internal-sample_case-processor
@@ -46,6 +51,8 @@ queueconfig:
   uac-update-topic: event_uac-update
   deactivate-uac-topic: event_deactivate-uac
   publishtimeout: 30  # In seconds
+  our-pubsub-project: our-project
+  shared-pubsub-project: project
 
 healthcheck:
   frequency: 15000 #milliseconds

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleLoadedIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleLoadedIT.java
@@ -75,7 +75,7 @@ public class SampleLoadedIT {
       sampleDto.setSample(sample);
       sampleDto.setSampleSensitive(sampleSensitive);
 
-      pubsubHelper.sendMessage(TOPIC_SAMPLE, sampleDto);
+      pubsubHelper.sendMessage(TOPIC_SAMPLE, sampleDto, true);
 
       //  THEN
       EventDTO actualEvent = outboundCaseQueueSpy.checkExpectedMessageReceived();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverIT.java
@@ -91,7 +91,7 @@ public class TelephoneCaptureReceiverIT {
 
     try (QueueSpy<EventDTO> outboundUacQueueSpy =
         pubsubHelper.listen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
-      pubsubHelper.sendMessage(TELEPHONE_CAPTURE_TOPIC, event);
+      pubsubHelper.sendMessage(TELEPHONE_CAPTURE_TOPIC, event, true);
       EventDTO emittedEvent = outboundUacQueueSpy.checkExpectedMessageReceived();
 
       assertThat(emittedEvent.getHeader().getTopic()).isEqualTo(uacUpdateTopic);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ssdc.caseprocessor.schedule;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
@@ -33,7 +32,6 @@ import uk.gov.ons.ssdc.caseprocessor.model.repository.UacQidLinkRepository;
 import uk.gov.ons.ssdc.caseprocessor.testutils.DeleteDataHelper;
 import uk.gov.ons.ssdc.caseprocessor.testutils.PubsubHelper;
 import uk.gov.ons.ssdc.caseprocessor.testutils.QueueSpy;
-import uk.gov.ons.ssdc.caseprocessor.utils.ObjectMapperFactory;
 
 @ContextConfiguration
 @SpringBootTest
@@ -61,11 +59,9 @@ public class ActionRuleIT {
   @Autowired private PrintTemplateRepository printTemplateRepository;
   @Autowired private ActionRuleRepository actionRuleRepository;
 
-  private static final ObjectMapper objectMapper = ObjectMapperFactory.objectMapper();
-
   @BeforeEach
   public void setUp() {
-    pubsubHelper.purgeMessages(OUTBOUND_PRINTER_SUBSCRIPTION, printTopic);
+    pubsubHelper.purgeMessages(OUTBOUND_PRINTER_SUBSCRIPTION, printTopic, true);
     pubsubHelper.purgeMessages(OUTBOUND_UAC_SUBSCRIPTION, uacUpdateTopic);
     deleteDataHelper.deleteAllData();
   }
@@ -73,7 +69,7 @@ public class ActionRuleIT {
   @Test
   public void testPrinterRule() throws Exception {
     try (QueueSpy<PrintRow> printerQueue =
-            pubsubHelper.listen(OUTBOUND_PRINTER_SUBSCRIPTION, PrintRow.class);
+            pubsubHelper.listen(OUTBOUND_PRINTER_SUBSCRIPTION, PrintRow.class, true);
         QueueSpy<EventDTO> outboundUacQueue =
             pubsubHelper.listen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
       // Given

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/FulfilmentIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/FulfilmentIT.java
@@ -70,7 +70,7 @@ public class FulfilmentIT {
 
   @BeforeEach
   public void setUp() {
-    pubsubHelper.purgeMessages(OUTBOUND_PRINTER_SUBSCRIPTION, printTopic);
+    pubsubHelper.purgeMessages(OUTBOUND_PRINTER_SUBSCRIPTION, printTopic, true);
     pubsubHelper.purgeMessages(OUTBOUND_UAC_SUBSCRIPTION, uacUpdateTopic);
     deleteDataHelper.deleteAllData();
   }
@@ -78,7 +78,7 @@ public class FulfilmentIT {
   @Test
   public void testFulfilmentTrigger() throws Exception {
     try (QueueSpy<PrintRow> printerQueue =
-            pubsubHelper.listen(OUTBOUND_PRINTER_SUBSCRIPTION, PrintRow.class);
+            pubsubHelper.listen(OUTBOUND_PRINTER_SUBSCRIPTION, PrintRow.class, true);
         QueueSpy<EventDTO> outboundUacQueue =
             pubsubHelper.listen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
       // Given

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
@@ -73,7 +73,7 @@ public class PrintProcessorTest {
 
     // Then
     ArgumentCaptor<PrintRow> printRowArgumentCaptor = ArgumentCaptor.forClass(PrintRow.class);
-    verify(messageSender).sendMessage(eq(printTopic), printRowArgumentCaptor.capture());
+    verify(messageSender).sendMessage(eq(printTopic), printRowArgumentCaptor.capture(), eq(true));
     PrintRow actualPrintRow = printRowArgumentCaptor.getValue();
     assertThat(actualPrintRow.getPackCode()).isEqualTo("test pack code");
     assertThat(actualPrintRow.getPrintSupplier()).isEqualTo("test print supplier");
@@ -127,7 +127,7 @@ public class PrintProcessorTest {
 
     // Then
     ArgumentCaptor<PrintRow> printRowArgumentCaptor = ArgumentCaptor.forClass(PrintRow.class);
-    verify(messageSender).sendMessage(eq(printTopic), printRowArgumentCaptor.capture());
+    verify(messageSender).sendMessage(eq(printTopic), printRowArgumentCaptor.capture(), eq(true));
     PrintRow actualPrintRow = printRowArgumentCaptor.getValue();
     assertThat(actualPrintRow.getPackCode()).isEqualTo("TEST_FULFILMENT_CODE");
     assertThat(actualPrintRow.getPrintSupplier()).isEqualTo("FOOBAR_PRINT_SUPPLIER");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConfig.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConfig.java
@@ -17,19 +17,15 @@ public class TestConfig {
 
   @Bean("ourProjectPubSubPublisherTemplateForIntegrationTests")
   public PubSubPublisherTemplate ourProjectPubSubPublisherTemplateForIntegrationTests(
-      @Qualifier("ourProjectPublisherFactory") PublisherFactory publisherFactory,
-      JacksonPubSubMessageConverter jacksonPubSubMessageConverterForIntegrationTests) {
+      @Qualifier("ourProjectPublisherFactory") PublisherFactory publisherFactory) {
     PubSubPublisherTemplate publisherTemplate = new PubSubPublisherTemplate(publisherFactory);
-    publisherTemplate.setMessageConverter(jacksonPubSubMessageConverterForIntegrationTests);
     return publisherTemplate;
   }
 
   @Bean("sharedProjectPubSubPublisherTemplateForIntegrationTests")
   public PubSubPublisherTemplate sharedProjectPubSubPublisherTemplateForIntegrationTests(
-      @Qualifier("sharedProjectPublisherFactory") PublisherFactory publisherFactory,
-      JacksonPubSubMessageConverter jacksonPubSubMessageConverterForIntegrationTests) {
+      @Qualifier("sharedProjectPublisherFactory") PublisherFactory publisherFactory) {
     PubSubPublisherTemplate publisherTemplate = new PubSubPublisherTemplate(publisherFactory);
-    publisherTemplate.setMessageConverter(jacksonPubSubMessageConverterForIntegrationTests);
     return publisherTemplate;
   }
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConfig.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConfig.java
@@ -1,8 +1,10 @@
 package uk.gov.ons.ssdc.caseprocessor.testutils;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
-import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,12 +14,47 @@ import uk.gov.ons.ssdc.caseprocessor.utils.ObjectMapperFactory;
 @Configuration
 @ActiveProfiles("test")
 public class TestConfig {
-  @Bean("pubSubTemplateForIntegrationTests")
-  public PubSubTemplate pubSubTemplateForIntegrationTests(
-      PublisherFactory publisherFactory,
-      SubscriberFactory subscriberFactory,
+
+  @Bean("ourProjectPubSubPublisherTemplateForIntegrationTests")
+  public PubSubPublisherTemplate ourProjectPubSubPublisherTemplateForIntegrationTests(
+      @Qualifier("ourProjectPublisherFactory") PublisherFactory publisherFactory,
       JacksonPubSubMessageConverter jacksonPubSubMessageConverterForIntegrationTests) {
-    PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
+    PubSubPublisherTemplate publisherTemplate = new PubSubPublisherTemplate(publisherFactory);
+    publisherTemplate.setMessageConverter(jacksonPubSubMessageConverterForIntegrationTests);
+    return publisherTemplate;
+  }
+
+  @Bean("sharedProjectPubSubPublisherTemplateForIntegrationTests")
+  public PubSubPublisherTemplate sharedProjectPubSubPublisherTemplateForIntegrationTests(
+      @Qualifier("sharedProjectPublisherFactory") PublisherFactory publisherFactory,
+      JacksonPubSubMessageConverter jacksonPubSubMessageConverterForIntegrationTests) {
+    PubSubPublisherTemplate publisherTemplate = new PubSubPublisherTemplate(publisherFactory);
+    publisherTemplate.setMessageConverter(jacksonPubSubMessageConverterForIntegrationTests);
+    return publisherTemplate;
+  }
+
+  @Bean("sharedProjectPubSubTemplateForIntegrationTests")
+  public PubSubTemplate sharedProjectPubSubTemplateForIntegrationTests(
+      @Qualifier("sharedProjectPubSubPublisherTemplateForIntegrationTests")
+          PubSubPublisherTemplate pubSubPublisherTemplate,
+      @Qualifier("sharedProjectPubSubSubscriberTemplate")
+          PubSubSubscriberTemplate pubSubSubscriberTemplate,
+      JacksonPubSubMessageConverter jacksonPubSubMessageConverterForIntegrationTests) {
+    PubSubTemplate pubSubTemplate =
+        new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
+    pubSubTemplate.setMessageConverter(jacksonPubSubMessageConverterForIntegrationTests);
+    return pubSubTemplate;
+  }
+
+  @Bean("ourProjectPubSubTemplateForIntegrationTests")
+  public PubSubTemplate ourProjectPubSubTemplateForIntegrationTests(
+      @Qualifier("ourProjectPubSubPublisherTemplateForIntegrationTests")
+          PubSubPublisherTemplate pubSubPublisherTemplate,
+      @Qualifier("ourProjectPubSubSubscriberTemplate")
+          PubSubSubscriberTemplate pubSubSubscriberTemplate,
+      JacksonPubSubMessageConverter jacksonPubSubMessageConverterForIntegrationTests) {
+    PubSubTemplate pubSubTemplate =
+        new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
     pubSubTemplate.setMessageConverter(jacksonPubSubMessageConverterForIntegrationTests);
     return pubSubTemplate;
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,7 +6,6 @@ spring:
     gcp:
       pubsub:
         emulator-host: localhost:18538
-        project-id: project
 
 uacservice:
   connection:

--- a/src/test/resources/setup_pubsub.sh
+++ b/src/test/resources/setup_pubsub.sh
@@ -3,44 +3,42 @@
 # Wait for pubsub-emulator to come up
 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' '$PUBSUB_SETUP_HOST')" != "200" ]]; do sleep 1; done'
 
-# Below are the minimum RM topics & events - ideally external systems will publish/subscribe to these, in the correct standardised format
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-telephone-capture
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-telephone-capture_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-telephone-capture"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/rm-internal-telephone-capture
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/rm-internal-telephone-capture_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/rm-internal-telephone-capture"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-sample
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-sample_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-sample"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/rm-internal-sample
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/rm-internal-sample_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/rm-internal-sample"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-print-row
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-print-row_print-file-service -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-print-row"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_receipt
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_receipt_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_receipt"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_receipt
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_receipt_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_receipt"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_refusal
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_refusal_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_refusal"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_refusal
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_refusal_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_refusal"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/rm-internal-print-row
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/rm-internal-print-row_print-file-service -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/rm-internal-print-row"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_invalid-case
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_invalid-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_invalid-case"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_invalid-case
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_invalid-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_invalid-case"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_survey-launch
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_survey-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_survey-launch"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_survey-launch
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_survey-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_survey-launch"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_uac-authentication
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_uac-authentication_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_uac-authentication"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_uac-authentication
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_uac-authentication_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_uac-authentication"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_print-fulfilment
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_print-fulfilment_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_print-fulfilment"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_print-fulfilment
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_print-fulfilment_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_print-fulfilment"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_deactivate-uac
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_deactivate-uac_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_deactivate-uac"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_deactivate-uac
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_deactivate-uac_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_deactivate-uac"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_update-sample-sensitive
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_update-sample-sensitive_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_update-sample-sensitive"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_update-sample-sensitive
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_update-sample-sensitive_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_update-sample-sensitive"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_case-update
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_case-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_case-update"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_case-update
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_case-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_case-update"}'
-
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_uac-update
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_uac-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_uac-update"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_uac-update
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_uac-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_uac-update"}'
 


### PR DESCRIPTION
# Motivation and Context
RM doesn't 'own' the topics and subscriptions which are used to integrate between other products... and as such, they should be kept in a shared project.

# What has changed
Use our own project only for internal messaging, otherwise use a shared project.

# How to test?
Build Case Processor and Support Tool, then start everything up in docker dev with `make up` and then run the acceptance tests with `make test`... should be zero regression.

# Links
Trello: https://trello.com/c/yPZ72ten