### PR TITLE
Preserve correlation ID and originating user across events

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/logging/EventLogger.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/logging/EventLogger.java
@@ -82,6 +82,7 @@ public class EventLogger {
     loggedEvent.setMessageId(event.getMessageId());
     loggedEvent.setMessageTimestamp(messageTimestamp);
     loggedEvent.setCreatedBy(event.getOriginatingUser());
+    loggedEvent.setCorrelationId(event.getCorrelationId());
 
     loggedEvent.setPayload(JsonHelper.convertObjectToJson(eventPayload));
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiver.java
@@ -33,7 +33,11 @@ public class DeactivateUacReceiver {
 
     OffsetDateTime messageTimestamp = getMsgTimeStamp(message);
     uacQidLink.setActive(false);
-    uacQidLink = uacService.saveAndEmitUacUpdateEvent(uacQidLink);
+    uacQidLink =
+        uacService.saveAndEmitUacUpdateEvent(
+            uacQidLink,
+            event.getHeader().getCorrelationId(),
+            event.getHeader().getOriginatingUser());
 
     eventLogger.logUacQidEvent(
         uacQidLink,

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiver.java
@@ -35,7 +35,8 @@ public class InvalidCaseReceiver {
 
     caze.setInvalid(true);
 
-    caseService.saveCaseAndEmitCaseUpdate(caze);
+    caseService.saveCaseAndEmitCaseUpdate(
+        caze, event.getHeader().getCorrelationId(), event.getHeader().getOriginatingUser());
 
     eventLogger.logCaseEvent(
         caze,

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiver.java
@@ -40,12 +40,17 @@ public class ReceiptReceiver {
 
     if (uacQidLink.isActive()) {
       uacQidLink.setActive(false);
-      uacQidLink = uacService.saveAndEmitUacUpdateEvent(uacQidLink);
+      uacQidLink =
+          uacService.saveAndEmitUacUpdateEvent(
+              uacQidLink,
+              event.getHeader().getCorrelationId(),
+              event.getHeader().getOriginatingUser());
 
       if (uacQidLink.getCaze() != null) {
         Case caze = uacQidLink.getCaze();
         caze.setReceiptReceived(true);
-        caseService.saveCaseAndEmitCaseUpdate(caze);
+        caseService.saveCaseAndEmitCaseUpdate(
+            caze, event.getHeader().getCorrelationId(), event.getHeader().getOriginatingUser());
       }
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
@@ -36,7 +36,8 @@ public class RefusalReceiver {
     OffsetDateTime messageTimestamp = getMsgTimeStamp(message);
     refusedCase.setRefusalReceived(RefusalType.valueOf(refusal.getType().name()));
 
-    caseService.saveCaseAndEmitCaseUpdate(refusedCase);
+    caseService.saveCaseAndEmitCaseUpdate(
+        refusedCase, event.getHeader().getCorrelationId(), event.getHeader().getOriginatingUser());
 
     eventLogger.logCaseEvent(
         refusedCase,

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SampleReceiver.java
@@ -73,14 +73,14 @@ public class SampleReceiver {
     newCase.setSampleSensitive(sample.getSampleSensitive());
 
     newCase = saveNewCaseAndStampCaseRef(newCase);
-    caseService.emitCaseUpdate(newCase);
+    caseService.emitCaseUpdate(newCase, sample.getJobId(), sample.getOriginatingUser());
 
     eventLogger.logCaseEvent(
         newCase,
         OffsetDateTime.now(),
         "New case created from sample load",
         EventType.NEW_CASE,
-        createEventDTO(TOPIC_SAMPLE),
+        createEventDTO(TOPIC_SAMPLE, sample.getJobId(), sample.getOriginatingUser()),
         RedactHelper.redact(sample),
         messageTimestamp);
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiver.java
@@ -60,7 +60,12 @@ public class SmsFulfilmentReceiver {
                 + smsFulfilment.getQid()
                 + " is already linked to a different case");
       }
-      uacService.createLinkAndEmitNewUacQid(caze, smsFulfilment.getUac(), smsFulfilment.getQid());
+      uacService.createLinkAndEmitNewUacQid(
+          caze,
+          smsFulfilment.getUac(),
+          smsFulfilment.getQid(),
+          event.getHeader().getCorrelationId(),
+          event.getHeader().getOriginatingUser());
     }
 
     eventLogger.logCaseEvent(

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SurveyLaunchReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SurveyLaunchReceiver.java
@@ -47,6 +47,9 @@ public class SurveyLaunchReceiver {
         messageTimestamp);
 
     uacQidLink.getCaze().setSurveyLaunched(true);
-    caseService.saveCaseAndEmitCaseUpdate(uacQidLink.getCaze());
+    caseService.saveCaseAndEmitCaseUpdate(
+        uacQidLink.getCaze(),
+        event.getHeader().getCorrelationId(),
+        event.getHeader().getOriginatingUser());
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiver.java
@@ -62,7 +62,11 @@ public class TelephoneCaptureReceiver {
     }
 
     uacService.createLinkAndEmitNewUacQid(
-        caze, telephoneCapturePayload.getUac(), telephoneCapturePayload.getQid());
+        caze,
+        telephoneCapturePayload.getUac(),
+        telephoneCapturePayload.getQid(),
+        event.getHeader().getCorrelationId(),
+        event.getHeader().getOriginatingUser());
 
     eventLogger.logCaseEvent(
         caze,

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/Sample.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/Sample.java
@@ -13,4 +13,7 @@ public class Sample {
   private Map<String, String> sample;
 
   private Map<String, String> sampleSensitive;
+
+  private UUID jobId;
+  private String originatingUser;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -32,17 +32,18 @@ public class CaseService {
     this.messageSender = messageSender;
   }
 
-  public void saveCaseAndEmitCaseUpdate(Case caze) {
+  public void saveCaseAndEmitCaseUpdate(Case caze, UUID correlationId, String originatingUser) {
     saveCase(caze);
-    emitCaseUpdate(caze);
+    emitCaseUpdate(caze, correlationId, originatingUser);
   }
 
   public void saveCase(Case caze) {
     caseRepository.saveAndFlush(caze);
   }
 
-  public void emitCaseUpdate(Case caze) {
-    EventHeaderDTO eventHeader = EventHelper.createEventDTO(caseUpdateTopic);
+  public void emitCaseUpdate(Case caze, UUID correlationId, String originatingUser) {
+    EventHeaderDTO eventHeader =
+        EventHelper.createEventDTO(caseUpdateTopic, correlationId, originatingUser);
 
     EventDTO event = prepareCaseEvent(caze, eventHeader);
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
@@ -28,9 +28,11 @@ public class CaseToProcessProcessor {
           caseToProcess.getBatchId(),
           caseToProcess.getBatchQuantity(),
           printTemplate.getPackCode(),
-          printTemplate.getPrintSupplier());
+          printTemplate.getPrintSupplier(),
+          caseToProcess.getActionRule().getId());
     } else if (actionRuleType == ActionRuleType.DEACTIVATE_UAC) {
-      deactivateUacProcessor.process(caseToProcess.getCaze());
+      deactivateUacProcessor.process(
+          caseToProcess.getCaze(), caseToProcess.getActionRule().getId());
     } else {
       throw new NotImplementedException("No implementation for other types of action rule yet");
     }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessor.java
@@ -4,6 +4,7 @@ import static com.google.cloud.spring.pubsub.support.PubSubTopicUtils.toProjectT
 import static uk.gov.ons.ssdc.caseprocessor.utils.EventHelper.createEventDTO;
 
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ssdc.caseprocessor.messaging.MessageSender;
@@ -28,20 +29,20 @@ public class DeactivateUacProcessor {
     this.messageSender = messageSender;
   }
 
-  public void process(Case caze) {
+  public void process(Case caze, UUID correlationId) {
     String topic = toProjectTopicName(deactivateUacTopic, sharedPubsubProject).toString();
     List<UacQidLink> uacQidLinks = caze.getUacQidLinks();
 
     for (UacQidLink uacQidLink : uacQidLinks) {
       if (uacQidLink.isActive()) {
-        EventDTO event = prepareDeactivateUacEvent(uacQidLink);
+        EventDTO event = prepareDeactivateUacEvent(uacQidLink, correlationId);
         messageSender.sendMessage(topic, event);
       }
     }
   }
 
-  private EventDTO prepareDeactivateUacEvent(UacQidLink uacQidLink) {
-    EventHeaderDTO eventHeader = createEventDTO(deactivateUacTopic);
+  private EventDTO prepareDeactivateUacEvent(UacQidLink uacQidLink, UUID correlationId) {
+    EventHeaderDTO eventHeader = createEventDTO(deactivateUacTopic, correlationId, null);
 
     EventDTO event = new EventDTO();
     event.setHeader(eventHeader);

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
@@ -109,7 +109,7 @@ public class PrintProcessor {
         OffsetDateTime.now(),
         String.format("Print file generated with pack code %s", packCode),
         EventType.PRINT_FILE,
-        EventHelper.getDummyEvent(),
+        EventHelper.getDummyEvent(correlationId),
         null,
         OffsetDateTime.now());
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
@@ -53,7 +53,8 @@ public class PrintProcessor {
         fulfilmentToProcess.getBatchId(),
         fulfilmentToProcess.getBatchQuantity(),
         printTemplate.getPackCode(),
-        printTemplate.getPrintSupplier());
+        printTemplate.getPrintSupplier(),
+        fulfilmentToProcess.getBatchId());
   }
 
   public void processPrintRow(
@@ -62,7 +63,8 @@ public class PrintProcessor {
       UUID batchId,
       int batchQuantity,
       String packCode,
-      String printSupplier) {
+      String printSupplier,
+      UUID correlationId) {
 
     UacQidDTO uacQidDTO = null;
     String[] rowStrings = new String[template.length];
@@ -76,14 +78,14 @@ public class PrintProcessor {
           break;
         case "__uac__":
           if (uacQidDTO == null) {
-            uacQidDTO = getUacQidForCase(caze);
+            uacQidDTO = getUacQidForCase(caze, correlationId);
           }
 
           rowStrings[i] = uacQidDTO.getUac();
           break;
         case "__qid__":
           if (uacQidDTO == null) {
-            uacQidDTO = getUacQidForCase(caze);
+            uacQidDTO = getUacQidForCase(caze, correlationId);
           }
 
           rowStrings[i] = uacQidDTO.getQid();
@@ -120,14 +122,14 @@ public class PrintProcessor {
     return csvRow;
   }
 
-  public UacQidDTO getUacQidForCase(Case caze) {
+  public UacQidDTO getUacQidForCase(Case caze, UUID correlationId) {
     UacQidDTO uacQidDTO = uacQidCache.getUacQidPair(1);
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setQid(uacQidDTO.getQid());
     uacQidLink.setUac(uacQidDTO.getUac());
     uacQidLink.setCaze(caze);
-    uacService.saveAndEmitUacUpdateEvent(uacQidLink);
+    uacService.saveAndEmitUacUpdateEvent(uacQidLink, correlationId, null);
 
     return uacQidDTO;
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
@@ -33,10 +33,12 @@ public class UacService {
     this.uacQidLinkRepository = uacQidLinkRepository;
   }
 
-  public UacQidLink saveAndEmitUacUpdateEvent(UacQidLink uacQidLink) {
+  public UacQidLink saveAndEmitUacUpdateEvent(
+      UacQidLink uacQidLink, UUID correlationId, String originatingUser) {
     UacQidLink savedUacQidLink = uacQidLinkRepository.save(uacQidLink);
 
-    EventHeaderDTO eventHeader = EventHelper.createEventDTO(uacUpdateTopic);
+    EventHeaderDTO eventHeader =
+        EventHelper.createEventDTO(uacUpdateTopic, correlationId, originatingUser);
 
     UacUpdateDTO uac = new UacUpdateDTO();
     uac.setQid(savedUacQidLink.getQid());
@@ -75,12 +77,13 @@ public class UacService {
     return uacQidLinkRepository.existsByQid(qid);
   }
 
-  public void createLinkAndEmitNewUacQid(Case caze, String uac, String qid) {
+  public void createLinkAndEmitNewUacQid(
+      Case caze, String uac, String qid, UUID correlationId, String originatingUser) {
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setUac(uac);
     uacQidLink.setQid(qid);
     uacQidLink.setCaze(caze);
-    saveAndEmitUacUpdateEvent(uacQidLink);
+    saveAndEmitUacUpdateEvent(uacQidLink, correlationId, originatingUser);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
@@ -12,7 +12,11 @@ public class EventHelper {
   private static final String EVENT_CHANNEL = "RM";
 
   public static EventHeaderDTO createEventDTO(
-      String topic, String eventChannel, String eventSource) {
+      String topic,
+      String eventChannel,
+      String eventSource,
+      UUID correlationId,
+      String originatingUser) {
     EventHeaderDTO eventHeader = new EventHeaderDTO();
 
     eventHeader.setVersion(EVENT_SCHEMA_VERSION);
@@ -20,13 +24,16 @@ public class EventHelper {
     eventHeader.setSource(eventSource);
     eventHeader.setDateTime(OffsetDateTime.now());
     eventHeader.setMessageId(UUID.randomUUID());
+    eventHeader.setCorrelationId(correlationId);
+    eventHeader.setOriginatingUser(originatingUser);
     eventHeader.setTopic(topic);
 
     return eventHeader;
   }
 
-  public static EventHeaderDTO createEventDTO(String topic) {
-    return createEventDTO(topic, EVENT_CHANNEL, EVENT_SOURCE);
+  public static EventHeaderDTO createEventDTO(
+      String topic, UUID correlationId, String originatingUser) {
+    return createEventDTO(topic, EVENT_CHANNEL, EVENT_SOURCE, correlationId, originatingUser);
   }
 
   public static EventHeaderDTO getDummyEvent() {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
@@ -36,12 +36,13 @@ public class EventHelper {
     return createEventDTO(topic, EVENT_CHANNEL, EVENT_SOURCE, correlationId, originatingUser);
   }
 
-  public static EventHeaderDTO getDummyEvent() {
+  public static EventHeaderDTO getDummyEvent(UUID correlationId) {
     EventHeaderDTO event = new EventHeaderDTO();
 
     event.setChannel(EVENT_CHANNEL);
     event.setSource(EVENT_SOURCE);
     event.setMessageId(UUID.randomUUID());
+    event.setCorrelationId(correlationId);
 
     return event;
   }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/logging/EventLoggerTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/logging/EventLoggerTest.java
@@ -2,6 +2,8 @@ package uk.gov.ons.ssdc.caseprocessor.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
@@ -30,7 +32,8 @@ public class EventLoggerTest {
     Case caze = new Case();
     OffsetDateTime eventTime = OffsetDateTime.now();
     OffsetDateTime messageTime = OffsetDateTime.now().minusSeconds(30);
-    EventHeaderDTO eventHeader = EventHelper.createEventDTO("Test topic");
+    EventHeaderDTO eventHeader =
+        EventHelper.createEventDTO("Test topic", TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
     eventHeader.setSource("Test source");
     eventHeader.setChannel("Test channel");
 
@@ -59,6 +62,8 @@ public class EventLoggerTest {
     assertThat("Test description").isEqualTo(actualEvent.getDescription());
     assertThat("{\"uac\":\"REDACTED\",\"qid\":\"TEST QID\"}").isEqualTo(actualEvent.getPayload());
     assertThat(eventHeader.getMessageId()).isEqualTo(actualEvent.getMessageId());
+    assertThat(eventHeader.getCorrelationId()).isEqualTo(actualEvent.getCorrelationId());
+    assertThat(eventHeader.getOriginatingUser()).isEqualTo(actualEvent.getCreatedBy());
     assertThat(messageTime).isEqualTo(actualEvent.getMessageTimestamp());
   }
 
@@ -67,7 +72,8 @@ public class EventLoggerTest {
     UacQidLink uacQidLink = new UacQidLink();
     OffsetDateTime eventTime = OffsetDateTime.now();
     OffsetDateTime messageTime = OffsetDateTime.now().minusSeconds(30);
-    EventHeaderDTO eventHeader = EventHelper.createEventDTO("Test topic");
+    EventHeaderDTO eventHeader =
+        EventHelper.createEventDTO("Test topic", TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
     eventHeader.setSource("Test source");
     eventHeader.setChannel("Test channel");
 
@@ -96,6 +102,8 @@ public class EventLoggerTest {
     assertThat("Test description").isEqualTo(actualEvent.getDescription());
     assertThat("{\"uac\":\"REDACTED\",\"qid\":\"TEST QID\"}").isEqualTo(actualEvent.getPayload());
     assertThat(eventHeader.getMessageId()).isEqualTo(actualEvent.getMessageId());
+    assertThat(eventHeader.getCorrelationId()).isEqualTo(actualEvent.getCorrelationId());
+    assertThat(eventHeader.getOriginatingUser()).isEqualTo(actualEvent.getCreatedBy());
     assertThat(messageTime).isEqualTo(actualEvent.getMessageTimestamp());
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessageWithValidTimeStamp;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
 import static uk.gov.ons.ssdc.caseprocessor.utils.MsgDateHelper.getMsgTimeStamp;
 
@@ -41,6 +43,8 @@ public class InvalidCaseReceiverTest {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
     managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    managementEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));
     managementEvent.getHeader().setTopic("Test topic");
     managementEvent.getHeader().setChannel("CC");
@@ -60,7 +64,9 @@ public class InvalidCaseReceiverTest {
     // then
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
 
-    verify(caseService).saveCaseAndEmitCaseUpdate(caseArgumentCaptor.capture());
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdate(
+            caseArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase.isInvalid()).isTrue();
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessageWithValidTimeStamp;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
@@ -51,6 +53,8 @@ public class RefusalReceiverTest {
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
+    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     eventHeader.setTopic("Test topic");
     eventHeader.setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
 
@@ -71,7 +75,9 @@ public class RefusalReceiverTest {
 
     // Then
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveCaseAndEmitCaseUpdate(caseArgumentCaptor.capture());
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdate(
+            caseArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
     Case actualCase = caseArgumentCaptor.getValue();
 
     assertThat(actualCase.getId()).isEqualTo(CASE_ID);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
@@ -2,11 +2,14 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessageWithValidTimeStamp;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
 import static uk.gov.ons.ssdc.caseprocessor.utils.MsgDateHelper.getMsgTimeStamp;
 
@@ -59,7 +62,9 @@ class SmsFulfilmentReceiverTest {
     underTest.receiveMessage(eventMessage);
 
     // Then
-    verify(uacService).createLinkAndEmitNewUacQid(testCase, TEST_UAC, TEST_QID);
+    verify(uacService)
+        .createLinkAndEmitNewUacQid(
+            testCase, TEST_UAC, TEST_QID, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
     verify(eventLogger)
         .logCaseEvent(
             testCase,
@@ -118,7 +123,7 @@ class SmsFulfilmentReceiverTest {
     underTest.receiveMessage(eventMessage);
 
     // Then
-    verify(uacService, never()).saveAndEmitUacUpdateEvent(any());
+    verify(uacService, never()).saveAndEmitUacUpdateEvent(any(), any(UUID.class), anyString());
     verifyNoInteractions(eventLogger);
   }
 
@@ -162,6 +167,8 @@ class SmsFulfilmentReceiverTest {
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
+    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setEnrichedSmsFulfilment(enrichedSmsFulfilment);
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SurveyLaunchReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SurveyLaunchReceiverTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessageWithValidTimeStamp;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
@@ -45,6 +47,8 @@ public class SurveyLaunchReceiverTest {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
     managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    managementEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
     managementEvent.getHeader().setTopic("Test topic");
     managementEvent.getHeader().setChannel("RH");
@@ -71,7 +75,9 @@ public class SurveyLaunchReceiverTest {
     verify(uacService).findByQid(TEST_QID_ID);
 
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveCaseAndEmitCaseUpdate(caseArgumentCaptor.capture());
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdate(
+            caseArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
     assertThat(caseArgumentCaptor.getValue().getId()).isEqualTo(TEST_CASE_ID);
     assertThat(caseArgumentCaptor.getValue().isSurveyLaunched()).isTrue();
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessageWithValidTimeStamp;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
 import static uk.gov.ons.ssdc.caseprocessor.utils.MsgDateHelper.getMsgTimeStamp;
 
@@ -55,7 +57,9 @@ class TelephoneCaptureReceiverTest {
     underTest.receiveMessage(eventMessage);
 
     // Then
-    verify(uacService).createLinkAndEmitNewUacQid(testCase, TEST_UAC, TEST_QID);
+    verify(uacService)
+        .createLinkAndEmitNewUacQid(
+            testCase, TEST_UAC, TEST_QID, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
 
     verify(eventLogger)
         .logCaseEvent(
@@ -89,7 +93,7 @@ class TelephoneCaptureReceiverTest {
     underTest.receiveMessage(eventMessage);
 
     // Then
-    verify(uacService, never()).saveAndEmitUacUpdateEvent(any());
+    verify(uacService, never()).saveAndEmitUacUpdateEvent(any(), any(UUID.class), anyString());
     verifyNoInteractions(eventLogger);
   }
 
@@ -127,6 +131,8 @@ class TelephoneCaptureReceiverTest {
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
+    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setTelephoneCapture(telephoneCaptureDTO);
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessorTest.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ssdc.caseprocessor.service;
 import static org.mockito.Mockito.verify;
 
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -34,6 +35,7 @@ public class CaseToProcessProcessorTest {
     printTemplate.setPrintSupplier("test print supplier");
 
     ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
     actionRule.setType(ActionRuleType.PRINT);
     actionRule.setPrintTemplate(printTemplate);
 
@@ -52,7 +54,8 @@ public class CaseToProcessProcessorTest {
             caseToProcess.getBatchId(),
             caseToProcess.getBatchQuantity(),
             printTemplate.getPackCode(),
-            printTemplate.getPrintSupplier());
+            printTemplate.getPrintSupplier(),
+            actionRule.getId());
   }
 
   @Test
@@ -61,6 +64,7 @@ public class CaseToProcessProcessorTest {
     Case caze = new Case();
 
     ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
     actionRule.setType(ActionRuleType.DEACTIVATE_UAC);
 
     CaseToProcess caseToProcess = new CaseToProcess();
@@ -71,6 +75,6 @@ public class CaseToProcessProcessorTest {
     underTest.process(caseToProcess);
 
     // Then
-    verify(deactivateUacProcessor).process(caze);
+    verify(deactivateUacProcessor).process(caze, actionRule.getId());
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/DeactivateUacProcessorTest.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ssdc.caseprocessor.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -38,12 +39,15 @@ public class DeactivateUacProcessorTest {
     caze.setUacQidLinks(List.of(uacQidLink));
 
     // When
-    underTest.process(caze);
+    underTest.process(caze, TEST_CORRELATION_ID);
 
     // Then
     ArgumentCaptor<EventDTO> eventArgumentCaptor = ArgumentCaptor.forClass(EventDTO.class);
     verify(messageSender)
         .sendMessage(eq("projects/Test project/topics/testTopic"), eventArgumentCaptor.capture());
+    assertThat(eventArgumentCaptor.getValue().getHeader().getCorrelationId())
+        .isEqualTo(TEST_CORRELATION_ID);
+
     DeactivateUacDTO actualDeactivateUac =
         eventArgumentCaptor.getValue().getPayload().getDeactivateUac();
     assertThat(actualDeactivateUac.getQid()).isEqualTo(uacQidLink.getQid());

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
@@ -48,6 +48,7 @@ public class PrintProcessorTest {
     printTemplate.setPrintSupplier("test print supplier");
 
     ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
     actionRule.setType(ActionRuleType.PRINT);
     actionRule.setPrintTemplate(printTemplate);
 
@@ -69,7 +70,8 @@ public class PrintProcessorTest {
         caseToProcess.getBatchId(),
         caseToProcess.getBatchQuantity(),
         printTemplate.getPackCode(),
-        printTemplate.getPrintSupplier());
+        printTemplate.getPrintSupplier(),
+        actionRule.getId());
 
     // Then
     ArgumentCaptor<PrintRow> printRowArgumentCaptor = ArgumentCaptor.forClass(PrintRow.class);
@@ -80,7 +82,8 @@ public class PrintProcessorTest {
     assertThat(actualPrintRow.getRow()).isEqualTo("\"123\"|\"test uac\"|\"bar\"");
 
     ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(uacService).saveAndEmitUacUpdateEvent(uacQidLinkCaptor.capture());
+    verify(uacService)
+        .saveAndEmitUacUpdateEvent(uacQidLinkCaptor.capture(), eq(actionRule.getId()), isNull());
     UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
     assertThat(actualUacQidLink.getUac()).isEqualTo("test uac");
     assertThat(actualUacQidLink.getQid()).isEqualTo("test qid");
@@ -134,7 +137,9 @@ public class PrintProcessorTest {
     assertThat(actualPrintRow.getRow()).isEqualTo("\"123\"|\"test uac\"|\"bar\"");
 
     ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(uacService).saveAndEmitUacUpdateEvent(uacQidLinkCaptor.capture());
+    verify(uacService)
+        .saveAndEmitUacUpdateEvent(
+            uacQidLinkCaptor.capture(), eq(fulfilmentToProcess.getBatchId()), isNull());
     UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
     assertThat(actualUacQidLink.getUac()).isEqualTo("test uac");
     assertThat(actualUacQidLink.getQid()).isEqualTo("test qid");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConstants.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConstants.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.testutils;
 
+import java.util.UUID;
+
 public class TestConstants {
   public static final String OUR_PUBSUB_PROJECT = "our-project";
   public static final String OUTBOUND_UAC_SUBSCRIPTION = "event_uac-update_rh";
@@ -7,4 +9,7 @@ public class TestConstants {
 
   public static final String TELEPHONE_CAPTURE_TOPIC = "rm-internal-telephone-capture";
   public static final String SMS_FULFILMENT_TOPIC = "rm-internal-sms-fulfilment";
+
+  public static final UUID TEST_CORRELATION_ID = UUID.randomUUID();
+  public static final String TEST_ORIGINATING_USER = "foo@bar.com";
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
@@ -1,6 +1,8 @@
 package uk.gov.ons.ssdc.caseprocessor.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
@@ -12,9 +14,12 @@ public class EventHelperTest {
 
   @Test
   public void testCreateEventDTOWithEventType() {
-    EventHeaderDTO eventHeader = EventHelper.createEventDTO("TOPIC");
+    EventHeaderDTO eventHeader =
+        EventHelper.createEventDTO("TOPIC", TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
 
     assertThat(eventHeader.getVersion()).isEqualTo(EVENT_SCHEMA_VERSION);
+    assertThat(eventHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);
+    assertThat(eventHeader.getOriginatingUser()).isEqualTo(TEST_ORIGINATING_USER);
     assertThat(eventHeader.getTopic()).isEqualTo("TOPIC");
     assertThat(eventHeader.getChannel()).isEqualTo("RM");
     assertThat(eventHeader.getSource()).isEqualTo("CASE_PROCESSOR");
@@ -24,9 +29,13 @@ public class EventHelperTest {
 
   @Test
   public void testCreateEventDTOWithEventTypeChannelAndSource() {
-    EventHeaderDTO eventHeader = EventHelper.createEventDTO("TOPIC", "CHANNEL", "SOURCE");
+    EventHeaderDTO eventHeader =
+        EventHelper.createEventDTO(
+            "TOPIC", "CHANNEL", "SOURCE", TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
 
     assertThat(eventHeader.getVersion()).isEqualTo(EVENT_SCHEMA_VERSION);
+    assertThat(eventHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);
+    assertThat(eventHeader.getOriginatingUser()).isEqualTo(TEST_ORIGINATING_USER);
     assertThat(eventHeader.getChannel()).isEqualTo("CHANNEL");
     assertThat(eventHeader.getSource()).isEqualTo("SOURCE");
     assertThat(eventHeader.getDateTime()).isInstanceOf(OffsetDateTime.class);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
@@ -45,10 +45,11 @@ public class EventHelperTest {
 
   @Test
   public void testGetDummyEvent() {
-    EventHeaderDTO eventHeader = EventHelper.getDummyEvent();
+    EventHeaderDTO eventHeader = EventHelper.getDummyEvent(TEST_CORRELATION_ID);
 
     assertThat(eventHeader.getChannel()).isEqualTo("RM");
     assertThat(eventHeader.getSource()).isEqualTo("CASE_PROCESSOR");
     assertThat(eventHeader.getMessageId()).isInstanceOf(UUID.class);
+    assertThat(eventHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);
   }
 }


### PR DESCRIPTION
# Motivation and Context
Correlation IDs are incredibly useful for audit trail, digital forensics, debugging and diagnosing defects, "identifying training opportunities" and suchlike. They only work if they truly correlate related events together, end-to-end.

Likewise, having an audit trail of the originating user - where it's known - is useful too, and saves a lot of hassle trawling through load balancer logs, trying to figure out who initiated a particular chain of events.

# What has changed
Preserved the correlation ID and originating user, where it's known, across events and other cascading effects from the original cause.

# How to test?
Use the support tool to create various types of event (e.g. refusal, receipt etc) and check that the resulting case and UAC updates have the correlation ID on them, and originating user (where appropriate).

# Links
Trello: https://trello.com/c/ESjv6BOa