### PR TITLE
Fulfilments use correct correlation ID and originating user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>1.0.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiver.java
@@ -49,6 +49,8 @@ public class PrintFulfilmentReceiver {
     FulfilmentToProcess fulfilmentToProcess = new FulfilmentToProcess();
     fulfilmentToProcess.setPrintTemplate(printTemplate);
     fulfilmentToProcess.setCaze(caze);
+    fulfilmentToProcess.setCorrelationId(event.getHeader().getCorrelationId());
+    fulfilmentToProcess.setOriginatingUser(event.getHeader().getOriginatingUser());
 
     fulfilmentToProcessRepository.saveAndFlush(fulfilmentToProcess);
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
@@ -29,7 +29,8 @@ public class CaseToProcessProcessor {
           caseToProcess.getBatchQuantity(),
           printTemplate.getPackCode(),
           printTemplate.getPrintSupplier(),
-          caseToProcess.getActionRule().getId());
+          caseToProcess.getActionRule().getId(),
+          null);
     } else if (actionRuleType == ActionRuleType.DEACTIVATE_UAC) {
       deactivateUacProcessor.process(
           caseToProcess.getCaze(), caseToProcess.getActionRule().getId());

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessor.java
@@ -54,7 +54,8 @@ public class PrintProcessor {
         fulfilmentToProcess.getBatchQuantity(),
         printTemplate.getPackCode(),
         printTemplate.getPrintSupplier(),
-        fulfilmentToProcess.getBatchId());
+        fulfilmentToProcess.getCorrelationId(),
+        fulfilmentToProcess.getOriginatingUser());
   }
 
   public void processPrintRow(
@@ -64,7 +65,8 @@ public class PrintProcessor {
       int batchQuantity,
       String packCode,
       String printSupplier,
-      UUID correlationId) {
+      UUID correlationId,
+      String originatingUser) {
 
     UacQidDTO uacQidDTO = null;
     String[] rowStrings = new String[template.length];
@@ -78,14 +80,14 @@ public class PrintProcessor {
           break;
         case "__uac__":
           if (uacQidDTO == null) {
-            uacQidDTO = getUacQidForCase(caze, correlationId);
+            uacQidDTO = getUacQidForCase(caze, correlationId, originatingUser);
           }
 
           rowStrings[i] = uacQidDTO.getUac();
           break;
         case "__qid__":
           if (uacQidDTO == null) {
-            uacQidDTO = getUacQidForCase(caze, correlationId);
+            uacQidDTO = getUacQidForCase(caze, correlationId, originatingUser);
           }
 
           rowStrings[i] = uacQidDTO.getQid();
@@ -109,7 +111,7 @@ public class PrintProcessor {
         OffsetDateTime.now(),
         String.format("Print file generated with pack code %s", packCode),
         EventType.PRINT_FILE,
-        EventHelper.getDummyEvent(correlationId),
+        EventHelper.getDummyEvent(correlationId, originatingUser),
         null,
         OffsetDateTime.now());
   }
@@ -122,14 +124,14 @@ public class PrintProcessor {
     return csvRow;
   }
 
-  public UacQidDTO getUacQidForCase(Case caze, UUID correlationId) {
+  public UacQidDTO getUacQidForCase(Case caze, UUID correlationId, String originatingUser) {
     UacQidDTO uacQidDTO = uacQidCache.getUacQidPair(1);
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setQid(uacQidDTO.getQid());
     uacQidLink.setUac(uacQidDTO.getUac());
     uacQidLink.setCaze(caze);
-    uacService.saveAndEmitUacUpdateEvent(uacQidLink, correlationId, null);
+    uacService.saveAndEmitUacUpdateEvent(uacQidLink, correlationId, originatingUser);
 
     return uacQidDTO;
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
@@ -36,13 +36,14 @@ public class EventHelper {
     return createEventDTO(topic, EVENT_CHANNEL, EVENT_SOURCE, correlationId, originatingUser);
   }
 
-  public static EventHeaderDTO getDummyEvent(UUID correlationId) {
+  public static EventHeaderDTO getDummyEvent(UUID correlationId, String originatingUser) {
     EventHeaderDTO event = new EventHeaderDTO();
 
     event.setChannel(EVENT_CHANNEL);
     event.setSource(EVENT_SOURCE);
     event.setMessageId(UUID.randomUUID());
     event.setCorrelationId(correlationId);
+    event.setOriginatingUser(originatingUser);
 
     return event;
   }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessorTest.java
@@ -55,7 +55,8 @@ public class CaseToProcessProcessorTest {
             caseToProcess.getBatchQuantity(),
             printTemplate.getPackCode(),
             printTemplate.getPrintSupplier(),
-            actionRule.getId());
+            actionRule.getId(),
+            null);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/PrintProcessorTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -71,7 +74,8 @@ public class PrintProcessorTest {
         caseToProcess.getBatchQuantity(),
         printTemplate.getPackCode(),
         printTemplate.getPrintSupplier(),
-        actionRule.getId());
+        actionRule.getId(),
+        null);
 
     // Then
     ArgumentCaptor<PrintRow> printRowArgumentCaptor = ArgumentCaptor.forClass(PrintRow.class);
@@ -90,15 +94,19 @@ public class PrintProcessorTest {
     assertThat(actualUacQidLink.getCaze()).isEqualTo(caze);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
+    ArgumentCaptor<EventHeaderDTO> headerCaptor = ArgumentCaptor.forClass(EventHeaderDTO.class);
     verify(eventLogger)
         .logCaseEvent(
             eq(caze),
             any(OffsetDateTime.class),
             eq("Print file generated with pack code test pack code"),
             eq(EventType.PRINT_FILE),
-            any(EventHeaderDTO.class),
+            headerCaptor.capture(),
             isNull(),
             any(OffsetDateTime.class));
+
+    EventHeaderDTO actualHeader = headerCaptor.getValue();
+    Assertions.assertThat(actualHeader.getCorrelationId()).isEqualTo(actionRule.getId());
   }
 
   @Test
@@ -118,6 +126,8 @@ public class PrintProcessorTest {
     fulfilmentToProcess.setCaze(caze);
     fulfilmentToProcess.setBatchId(UUID.fromString("6a127d58-c1cb-489c-a3f5-72014a0c32d6"));
     fulfilmentToProcess.setBatchQuantity(200);
+    fulfilmentToProcess.setCorrelationId(TEST_CORRELATION_ID);
+    fulfilmentToProcess.setOriginatingUser(TEST_ORIGINATING_USER);
 
     UacQidDTO uacQidDTO = new UacQidDTO();
     uacQidDTO.setUac("test uac");
@@ -139,21 +149,26 @@ public class PrintProcessorTest {
     ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
     verify(uacService)
         .saveAndEmitUacUpdateEvent(
-            uacQidLinkCaptor.capture(), eq(fulfilmentToProcess.getBatchId()), isNull());
+            uacQidLinkCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
     UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
     assertThat(actualUacQidLink.getUac()).isEqualTo("test uac");
     assertThat(actualUacQidLink.getQid()).isEqualTo("test qid");
     assertThat(actualUacQidLink.getCaze()).isEqualTo(caze);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
+    ArgumentCaptor<EventHeaderDTO> headerCaptor = ArgumentCaptor.forClass(EventHeaderDTO.class);
     verify(eventLogger)
         .logCaseEvent(
             eq(caze),
             any(OffsetDateTime.class),
             eq("Print file generated with pack code TEST_FULFILMENT_CODE"),
             eq(EventType.PRINT_FILE),
-            any(EventHeaderDTO.class),
+            headerCaptor.capture(),
             isNull(),
             any(OffsetDateTime.class));
+
+    EventHeaderDTO actualHeader = headerCaptor.getValue();
+    Assertions.assertThat(actualHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);
+    Assertions.assertThat(actualHeader.getOriginatingUser()).isEqualTo(TEST_ORIGINATING_USER);
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
@@ -45,11 +45,13 @@ public class EventHelperTest {
 
   @Test
   public void testGetDummyEvent() {
-    EventHeaderDTO eventHeader = EventHelper.getDummyEvent(TEST_CORRELATION_ID);
+    EventHeaderDTO eventHeader =
+        EventHelper.getDummyEvent(TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
 
     assertThat(eventHeader.getChannel()).isEqualTo("RM");
     assertThat(eventHeader.getSource()).isEqualTo("CASE_PROCESSOR");
     assertThat(eventHeader.getMessageId()).isInstanceOf(UUID.class);
     assertThat(eventHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);
+    assertThat(eventHeader.getOriginatingUser()).isEqualTo(TEST_ORIGINATING_USER);
   }
 }


### PR DESCRIPTION
# Motivation and Context
We should be able to correlate a fulfilment _request_ with the subsequent printing of it, which happens when fulfilments trigger.

# What has changed
Stored the correlation ID and originating user against fulfilments in the table where they are held, waiting until the trigger time arrives.

# How to test?
Run the ATs. Try using the Support Tool to request a paper fulfilment.

# Links
Trello: https://trello.com/c/v3nc5EHo