### PR TITLE
Rename surveylaunch eqlaunch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.3.0-HB</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>1.3.0-HB</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
@@ -37,8 +37,8 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.invalid-case-subscription}")
   private String invalidCaseSubscription;
 
-  @Value("${queueconfig.survey-launch-subscription}")
-  private String surveyLaunchSubscription;
+  @Value("${queueconfig.eq-launch-subscription}")
+  private String eqLaunchSubscription;
 
   @Value("${queueconfig.uac-authentication-subscription}")
   private String uacAuthenticationSubscription;
@@ -82,7 +82,7 @@ public class MessageConsumerConfig {
   }
 
   @Bean
-  public MessageChannel surveyLaunchInputChannel() {
+  public MessageChannel eqLaunchInputChannel() {
     return new DirectChannel();
   }
 
@@ -147,10 +147,10 @@ public class MessageConsumerConfig {
   }
 
   @Bean
-  PubSubInboundChannelAdapter surveyLaunchedInbound(
-      @Qualifier("surveyLaunchInputChannel") MessageChannel channel) {
+  PubSubInboundChannelAdapter eqLaunchedInbound(
+      @Qualifier("eqLaunchInputChannel") MessageChannel channel) {
     String subscription =
-        toProjectSubscriptionName(surveyLaunchSubscription, sharedPubsubProject).toString();
+        toProjectSubscriptionName(eqLaunchSubscription, sharedPubsubProject).toString();
     return makeAdapter(channel, subscription);
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiver.java
@@ -16,37 +16,36 @@ import uk.gov.ons.ssdc.common.model.entity.EventType;
 import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 
 @MessageEndpoint
-public class SurveyLaunchReceiver {
+public class EqLaunchReceiver {
   private final UacService uacService;
   private final CaseService caseService;
   private final EventLogger eventLogger;
 
-  public SurveyLaunchReceiver(
-      UacService uacService, CaseService caseService, EventLogger eventLogger) {
+  public EqLaunchReceiver(UacService uacService, CaseService caseService, EventLogger eventLogger) {
     this.uacService = uacService;
     this.caseService = caseService;
     this.eventLogger = eventLogger;
   }
 
   @Transactional
-  @ServiceActivator(inputChannel = "surveyLaunchInputChannel", adviceChain = "retryAdvice")
+  @ServiceActivator(inputChannel = "eqLaunchInputChannel", adviceChain = "retryAdvice")
   public void receiveMessage(Message<byte[]> message) {
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
 
     OffsetDateTime messageTimestamp = getMsgTimeStamp(message);
 
-    UacQidLink uacQidLink = uacService.findByQid(event.getPayload().getSurveyLaunch().getQid());
+    UacQidLink uacQidLink = uacService.findByQid(event.getPayload().getEqLaunch().getQid());
 
     eventLogger.logUacQidEvent(
         uacQidLink,
         event.getHeader().getDateTime(),
-        "Survey launched",
-        EventType.SURVEY_LAUNCH,
+        "EQ launched",
+        EventType.EQ_LAUNCH,
         event.getHeader(),
         event.getPayload().getReceipt(),
         messageTimestamp);
 
-    uacQidLink.getCaze().setSurveyLaunched(true);
+    uacQidLink.getCaze().setEqLaunched(true);
     caseService.saveCaseAndEmitCaseUpdate(
         uacQidLink.getCaze(),
         event.getHeader().getCorrelationId(),

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
@@ -9,7 +9,7 @@ public class CaseUpdateDTO {
   private UUID caseId;
   private boolean receiptReceived;
   private boolean invalid;
-  private boolean surveyLaunched;
+  private boolean eqLaunched;
   private RefusalTypeDTO refusalReceived;
   private Map<String, String> sample;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EqLaunchDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EqLaunchDTO.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @JsonInclude(Include.NON_NULL)
-public class SurveyLaunchDTO {
+public class EqLaunchDTO {
   private String qid;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
@@ -16,7 +16,7 @@ public class PayloadDTO {
   private TelephoneCaptureDTO telephoneCapture;
   private DeactivateUacDTO deactivateUac;
   private UpdateSampleSensitive updateSampleSensitive;
-  private SurveyLaunchDTO surveyLaunch;
+  private EqLaunchDTO eqLaunch;
   private UacAuthenticationDTO uacAuthentication;
   private EnrichedSmsFulfilment enrichedSmsFulfilment;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -58,7 +58,7 @@ public class CaseService {
     caseUpdate.setSample(caze.getSample());
     caseUpdate.setReceiptReceived(caze.isReceiptReceived());
     caseUpdate.setInvalid(caze.isInvalid());
-    caseUpdate.setSurveyLaunched(caze.isSurveyLaunched());
+    caseUpdate.setEqLaunched(caze.isEqLaunched());
     if (caze.getRefusalReceived() != null) {
       caseUpdate.setRefusalReceived(RefusalTypeDTO.valueOf(caze.getRefusalReceived().name()));
     } else {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,7 @@ queueconfig:
   receipt-subscription: event_receipt_rm-case-processor
   refusal-subscription: event_refusal_rm-case-processor
   invalid-case-subscription: event_invalid-case_rm-case-processor
-  survey-launch-subscription: event_survey-launch_rm-case-processor
+  eq-launch-subscription: event_eq-launch_rm-case-processor
   uac-authentication-subscription: event_uac-authentication_rm-case-processor
   print-fulfilment-subscription: event_print-fulfilment_rm-case-processor
   deactivate-uac-subscription: event_deactivate-uac_rm-case-processor

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
@@ -20,10 +20,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EqLaunchDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
-import uk.gov.ons.ssdc.caseprocessor.model.dto.SurveyLaunchDTO;
 import uk.gov.ons.ssdc.caseprocessor.service.CaseService;
 import uk.gov.ons.ssdc.caseprocessor.service.UacService;
 import uk.gov.ons.ssdc.common.model.entity.Case;
@@ -31,7 +31,7 @@ import uk.gov.ons.ssdc.common.model.entity.EventType;
 import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 
 @ExtendWith(MockitoExtension.class)
-public class SurveyLaunchReceiverTest {
+public class EqLaunchReceiverTest {
 
   private final UUID TEST_CASE_ID = UUID.randomUUID();
   private final String TEST_QID_ID = "1234567890123456";
@@ -40,10 +40,10 @@ public class SurveyLaunchReceiverTest {
   @Mock private EventLogger eventLogger;
   @Mock private CaseService caseService;
 
-  @InjectMocks SurveyLaunchReceiver underTest;
+  @InjectMocks EqLaunchReceiver underTest;
 
   @Test
-  public void testSurveryLaunchedEventFromRH() {
+  public void testEqLaunchedEventFromRH() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
     managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
@@ -54,9 +54,9 @@ public class SurveyLaunchReceiverTest {
     managementEvent.getHeader().setChannel("RH");
     managementEvent.setPayload(new PayloadDTO());
 
-    SurveyLaunchDTO surveyLaunch = new SurveyLaunchDTO();
-    surveyLaunch.setQid(TEST_QID_ID);
-    managementEvent.getPayload().setSurveyLaunch(surveyLaunch);
+    EqLaunchDTO eqLaunch = new EqLaunchDTO();
+    eqLaunch.setQid(TEST_QID_ID);
+    managementEvent.getPayload().setEqLaunch(eqLaunch);
 
     UacQidLink expectedUacQidLink = new UacQidLink();
     expectedUacQidLink.setUac(TEST_QID_ID);
@@ -79,14 +79,14 @@ public class SurveyLaunchReceiverTest {
         .saveCaseAndEmitCaseUpdate(
             caseArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
     assertThat(caseArgumentCaptor.getValue().getId()).isEqualTo(TEST_CASE_ID);
-    assertThat(caseArgumentCaptor.getValue().isSurveyLaunched()).isTrue();
+    assertThat(caseArgumentCaptor.getValue().isEqLaunched()).isTrue();
 
     verify(eventLogger)
         .logUacQidEvent(
             eq(expectedUacQidLink),
             any(OffsetDateTime.class),
-            eq("Survey launched"),
-            eq(EventType.SURVEY_LAUNCH),
+            eq("EQ launched"),
+            eq(EventType.EQ_LAUNCH),
             eq(managementEvent.getHeader()),
             any(),
             any());

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UacAuthenticationReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UacAuthenticationReceiverIT.java
@@ -55,21 +55,21 @@ public class UacAuthenticationReceiverIT {
     uacQidLink.setCaze(junkDataHelper.setupJunkCase());
     uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    EventDTO surveyLaunchedEvent = new EventDTO();
+    EventDTO eqLaunchedEvent = new EventDTO();
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(EVENT_SCHEMA_VERSION);
     eventHeader.setTopic(INBOUND_TOPIC);
     junkDataHelper.junkify(eventHeader);
-    surveyLaunchedEvent.setHeader(eventHeader);
+    eqLaunchedEvent.setHeader(eventHeader);
 
     UacAuthenticationDTO uacAuthentication = new UacAuthenticationDTO();
     uacAuthentication.setQid(uacQidLink.getQid());
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setUacAuthentication(uacAuthentication);
-    surveyLaunchedEvent.setPayload(payloadDTO);
+    eqLaunchedEvent.setPayload(payloadDTO);
 
     // WHEN
-    pubsubHelper.sendMessageToSharedProject(INBOUND_TOPIC, surveyLaunchedEvent);
+    pubsubHelper.sendMessageToSharedProject(INBOUND_TOPIC, eqLaunchedEvent);
     Thread.sleep(2000);
 
     // THEN

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
@@ -43,7 +43,7 @@ public class CaseServiceTest {
     caze.setSample(Map.of("foo", "bar"));
     caze.setReceiptReceived(true);
     caze.setInvalid(true);
-    caze.setSurveyLaunched(true);
+    caze.setEqLaunched(true);
     caze.setRefusalReceived(RefusalType.HARD_REFUSAL);
 
     underTest.saveCaseAndEmitCaseUpdate(caze, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
@@ -63,7 +63,7 @@ public class CaseServiceTest {
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());
     assertThat(actualCaseUpdate.isReceiptReceived()).isTrue();
     assertThat(actualCaseUpdate.isInvalid()).isTrue();
-    assertThat(actualCaseUpdate.isSurveyLaunched()).isTrue();
+    assertThat(actualCaseUpdate.isEqLaunched()).isTrue();
     assertThat(actualCaseUpdate.getRefusalReceived()).isEqualTo(RefusalTypeDTO.HARD_REFUSAL);
   }
 
@@ -84,7 +84,7 @@ public class CaseServiceTest {
     caze.setSample(Map.of("foo", "bar"));
     caze.setReceiptReceived(true);
     caze.setInvalid(true);
-    caze.setSurveyLaunched(true);
+    caze.setEqLaunched(true);
     caze.setRefusalReceived(RefusalType.EXTRAORDINARY_REFUSAL);
 
     underTest.emitCaseUpdate(caze, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
@@ -103,7 +103,7 @@ public class CaseServiceTest {
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());
     assertThat(actualCaseUpdate.isReceiptReceived()).isTrue();
     assertThat(actualCaseUpdate.isInvalid()).isTrue();
-    assertThat(actualCaseUpdate.isSurveyLaunched()).isTrue();
+    assertThat(actualCaseUpdate.isEqLaunched()).isTrue();
     assertThat(actualCaseUpdate.getRefusalReceived())
         .isEqualTo(RefusalTypeDTO.EXTRAORDINARY_REFUSAL);
   }

--- a/src/test/resources/setup_pubsub.sh
+++ b/src/test/resources/setup_pubsub.sh
@@ -24,8 +24,8 @@ curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/e
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_invalid-case
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_invalid-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_invalid-case"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_survey-launch
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_survey-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_survey-launch"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_eq-launch
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_eq-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_eq-launch"}'
 
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_uac-authentication
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_uac-authentication_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_uac-authentication"}'


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
"survey launch" is misleading, because a survey is a set of collection exercises, and a set of collection instruments... what we're really talking about is a specific electronic questionnaire launch (which could be either Blaise or EQ).
We need to rename the topic, subscription, listener in case processor and all associated gubbins.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Survey launch has been changed to eq launch in all occurrences
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
`shift-ctrl-f` for surveyLaunch(ed), survey-launch, survey_launch - should be zero occurrences
Build all the services on the ticket, check they all build successfully
Run the ATs using the branch on the ticket
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/hOoco1AN/2752-rename-surveylaunch-to-eqlaunch-5
# Screenshots (if appropriate):
