### PR TITLE
Combine DDL and entities into one repo to rule them all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
       </releases>
       <snapshots>
         <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL10Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         default_schema: casev3

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -2,12 +2,10 @@ version: '2.1'
 services:
   postgres:
     container_name: postgres-case-it
-    image: postgres:13
+    image: rm-postgres-case-integration-testing:latest
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
     ports:
       - "15432:5432"
-    environment:
-      - POSTGRES_PASSWORD=postgres
 
   uac-qid:
     container_name: uac-qid-case-it

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   postgres:
     container_name: postgres-case-it
-    image: rm-postgres-case-integration-testing:latest
+    image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-dev-common-postgres:latest
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
     ports:
       - "15432:5432"


### PR DESCRIPTION
# Motivation and Context
It's a pain when we're making model changes, because we have to build case processor before the integration tests start passing in the other projects: Case API, Notify Service & Response Operations.

Also, having to remember to generate DDL changes in a different repo, when the model has been changed, is something that's easily forgotten/overlooked.

# What has changed
Combined the DDL and common entities repos. Built a Postgres image which we can use in all the repos that use the common data model.

# How to test?
Run the integration tests in all the projects... should still work.

# Links
Trello: https://trello.com/c/EBa69kMx