### PR TITLE
Create default task scheduler

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -6,13 +6,19 @@ import com.google.cloud.spring.pubsub.support.SubscriberFactory;
 import com.google.cloud.spring.pubsub.support.converter.SimplePubSubMessageConverter;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 public class AppConfig {
+  @Value("${spring.task.scheduling.pool.size}")
+  private int schedulingPoolSize;
+
   @Bean
   public PubSubTemplate pubSubTemplate(
       PublisherFactory publisherFactory,
@@ -26,6 +32,13 @@ public class AppConfig {
   @Bean
   public SimplePubSubMessageConverter messageConverter() {
     return new SimplePubSubMessageConverter();
+  }
+
+  @Bean
+  public TaskScheduler taskScheduler() {
+    ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    taskScheduler.setPoolSize(schedulingPoolSize);
+    return taskScheduler;
   }
 
   @PostConstruct


### PR DESCRIPTION
# Motivation and Context
There is some evidence of thread starvation, causing parallel sample loads to interfere with each other, and causing the heartbeat/healthcheck thread to be unable to update the keepalive, resulting in K8S pods being bounced that should not be.

# What has changed
Added a 'default' `taskScheduler` for Spring Boot to use.

# How to test?
It's hard... but try running multiple sample loads simultaneously. In truth though, we won't really know if this has improved anything until it's had a chance to 'soak' in the integration environment for a while.

# Links
Trello: https://trello.com/c/MPRzPGqL