### PR TITLE
Fix null payload for eqLaunch events

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiver.java
@@ -42,7 +42,7 @@ public class EqLaunchReceiver {
         "EQ launched",
         EventType.EQ_LAUNCH,
         event.getHeader(),
-        event.getPayload().getReceipt(),
+        event.getPayload().getEqLaunch(),
         messageTimestamp);
 
     uacQidLink.getCaze().setEqLaunched(true);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
@@ -88,7 +88,7 @@ public class EqLaunchReceiverTest {
             eq("EQ launched"),
             eq(EventType.EQ_LAUNCH),
             eq(managementEvent.getHeader()),
-            any(),
+            eq(eqLaunch),
             any());
 
     verifyNoMoreInteractions(uacService);


### PR DESCRIPTION
# Motivation and Context
There was a bug.

# What has changed
Made bug go away.

# How to test?
Send in an eqLaunch event and check that there's a payload on the event when it's saved in the database.

# Links
Trello: https://trello.com/c/YP6PqJd7