### PR TITLE
2668 move receipt to uac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.3.0-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiver.java
@@ -1,16 +1,13 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static uk.gov.ons.ssdc.caseprocessor.utils.JsonHelper.convertJsonBytesToEvent;
-import static uk.gov.ons.ssdc.caseprocessor.utils.MsgDateHelper.getMsgTimeStamp;
 
-import java.time.OffsetDateTime;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
-import uk.gov.ons.ssdc.caseprocessor.service.CaseService;
 import uk.gov.ons.ssdc.caseprocessor.service.UacService;
 import uk.gov.ons.ssdc.common.model.entity.EventType;
 import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
@@ -35,7 +32,6 @@ public class EqLaunchReceiver {
 
     uacQidLink.setEqLaunched(true);
     uacService.saveAndEmitUacUpdateEvent(
-            uacQidLink, event.getHeader().getCorrelationId(), event.getHeader().getOriginatingUser());
-
+        uacQidLink, event.getHeader().getCorrelationId(), event.getHeader().getOriginatingUser());
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiver.java
@@ -11,21 +11,17 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
-import uk.gov.ons.ssdc.caseprocessor.service.CaseService;
 import uk.gov.ons.ssdc.caseprocessor.service.UacService;
-import uk.gov.ons.ssdc.common.model.entity.Case;
 import uk.gov.ons.ssdc.common.model.entity.EventType;
 import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 
 @MessageEndpoint
 public class ReceiptReceiver {
   private final UacService uacService;
-  private final CaseService caseService;
   private final EventLogger eventLogger;
 
-  public ReceiptReceiver(UacService uacService, CaseService caseService, EventLogger eventLogger) {
+  public ReceiptReceiver(UacService uacService, EventLogger eventLogger) {
     this.uacService = uacService;
-    this.caseService = caseService;
     this.eventLogger = eventLogger;
   }
 
@@ -40,18 +36,13 @@ public class ReceiptReceiver {
 
     if (uacQidLink.isActive()) {
       uacQidLink.setActive(false);
+      uacQidLink.setReceiptReceived(true);
+
       uacQidLink =
           uacService.saveAndEmitUacUpdateEvent(
               uacQidLink,
               event.getHeader().getCorrelationId(),
               event.getHeader().getOriginatingUser());
-
-      if (uacQidLink.getCaze() != null) {
-        Case caze = uacQidLink.getCaze();
-        caze.setReceiptReceived(true);
-        caseService.saveCaseAndEmitCaseUpdate(
-            caze, event.getHeader().getCorrelationId(), event.getHeader().getOriginatingUser());
-      }
     }
 
     eventLogger.logUacQidEvent(

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
@@ -7,9 +7,7 @@ import lombok.Data;
 @Data
 public class CaseUpdateDTO {
   private UUID caseId;
-  private boolean receiptReceived;
   private boolean invalid;
-  private boolean eqLaunched;
   private RefusalTypeDTO refusalReceived;
   private Map<String, String> sample;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/UacUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/UacUpdateDTO.java
@@ -12,4 +12,6 @@ public class UacUpdateDTO {
   private boolean active;
   private String qid;
   private UUID caseId;
+  private boolean receiptReceived;
+  private boolean eqLaunched;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -56,9 +56,7 @@ public class CaseService {
     CaseUpdateDTO caseUpdate = new CaseUpdateDTO();
     caseUpdate.setCaseId(caze.getId());
     caseUpdate.setSample(caze.getSample());
-    caseUpdate.setReceiptReceived(caze.isReceiptReceived());
     caseUpdate.setInvalid(caze.isInvalid());
-    caseUpdate.setEqLaunched(caze.isEqLaunched());
     if (caze.getRefusalReceived() != null) {
       caseUpdate.setRefusalReceived(RefusalTypeDTO.valueOf(caze.getRefusalReceived().name()));
     } else {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
@@ -44,6 +44,8 @@ public class UacService {
     uac.setQid(savedUacQidLink.getQid());
     uac.setUacHash(HashHelper.hash(savedUacQidLink.getUac()));
     uac.setActive(savedUacQidLink.isActive());
+    uac.setReceiptReceived(savedUacQidLink.isReceiptReceived());
+    uac.setEqLaunched(savedUacQidLink.isEqLaunched());
 
     Case caze = savedUacQidLink.getCaze();
     if (caze != null) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
@@ -1,5 +1,5 @@
 package uk.gov.ons.ssdc.caseprocessor.utils;
 
 public class Constants {
-  public static final String EVENT_SCHEMA_VERSION = "v0.2_RELEASE";
+  public static final String EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverIT.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_CASE_SUBSCRIPTION;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
 
 import java.util.List;
@@ -19,6 +19,7 @@ import uk.gov.ons.ssdc.caseprocessor.model.dto.EqLaunchDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.UacUpdateDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.EventRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.UacQidLinkRepository;
 import uk.gov.ons.ssdc.caseprocessor.testutils.DeleteDataHelper;
@@ -37,8 +38,8 @@ public class EqLaunchReceiverIT {
   private static final String TEST_QID = "1234334";
   private static final String INBOUND_TOPIC = "event_eq-launch";
 
-  @Value("${queueconfig.case-update-topic}")
-  private String caseUpdateTopic;
+  @Value("${queueconfig.uac-update-topic}")
+  private String uacUpdateTopic;
 
   @Autowired private PubsubHelper pubsubHelper;
   @Autowired private DeleteDataHelper deleteDataHelper;
@@ -49,7 +50,7 @@ public class EqLaunchReceiverIT {
 
   @BeforeEach
   public void setUp() {
-    pubsubHelper.purgeSharedProjectMessages(OUTBOUND_CASE_SUBSCRIPTION, caseUpdateTopic);
+    pubsubHelper.purgeSharedProjectMessages(OUTBOUND_UAC_SUBSCRIPTION, uacUpdateTopic);
     deleteDataHelper.deleteAllData();
   }
 
@@ -57,8 +58,8 @@ public class EqLaunchReceiverIT {
   public void testEqLaunchLogsEventSetsFlagAndEmitsCorrectCaseUpdatedEvent() throws Exception {
     // GIVEN
 
-    try (QueueSpy<EventDTO> outboundCaseQueueSpy =
-        pubsubHelper.sharedProjectListen(OUTBOUND_CASE_SUBSCRIPTION, EventDTO.class)) {
+    try (QueueSpy<EventDTO> outboundUacQueueSpy =
+        pubsubHelper.sharedProjectListen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
       Case caze = junkDataHelper.setupJunkCase();
 
       UacQidLink uacQidLink = new UacQidLink();
@@ -67,6 +68,7 @@ public class EqLaunchReceiverIT {
       uacQidLink.setUac("Junk");
       uacQidLink.setQid(TEST_QID);
       uacQidLink.setCaze(caze);
+      uacQidLink.setEqLaunched(false);
       uacQidLinkRepository.saveAndFlush(uacQidLink);
 
       EventDTO eqLaunchedEvent = new EventDTO();
@@ -86,10 +88,9 @@ public class EqLaunchReceiverIT {
       pubsubHelper.sendMessageToSharedProject(INBOUND_TOPIC, eqLaunchedEvent);
 
       // THEN
-      EventDTO caseUpdatedEvent = outboundCaseQueueSpy.checkExpectedMessageReceived();
-
-      assertThat(caseUpdatedEvent.getPayload().getCaseUpdate().getCaseId()).isEqualTo(caze.getId());
-      assertThat(caseUpdatedEvent.getPayload().getCaseUpdate().isEqLaunched()).isTrue();
+      EventDTO uacUpdatedEvent = outboundUacQueueSpy.checkExpectedMessageReceived();
+      UacUpdateDTO emittedUac = uacUpdatedEvent.getPayload().getUacUpdate();
+      assertThat(emittedUac.isEqLaunched()).isTrue();
 
       List<Event> events = eventRepository.findAll();
       assertThat(events.size()).isEqualTo(1);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverIT.java
@@ -55,7 +55,7 @@ public class EqLaunchReceiverIT {
   }
 
   @Test
-  public void testEqLaunchLogsEventSetsFlagAndEmitsCorrectCaseUpdatedEvent() throws Exception {
+  public void testEqLaunchLogsEventSetsFlagAndEmitsCorrectUACUpdatedEvent() throws Exception {
     // GIVEN
 
     try (QueueSpy<EventDTO> outboundUacQueueSpy =

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
@@ -11,7 +11,6 @@ import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -30,8 +29,6 @@ import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 
 @ExtendWith(MockitoExtension.class)
 public class EqLaunchReceiverTest {
-
-  private final UUID TEST_CASE_ID = UUID.randomUUID();
   private final String TEST_QID_ID = "1234567890123456";
 
   @Mock private UacService uacService;

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
@@ -10,7 +10,6 @@ import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -54,7 +53,7 @@ public class EqLaunchReceiverTest {
 
     UacQidLink expectedUacQidLink = new UacQidLink();
     expectedUacQidLink.setQid(TEST_QID_ID);
-    Message<byte[]> message = constructMessageWithValidTimeStamp(managementEvent);
+    Message<byte[]> message = constructMessage(managementEvent);
 
     // Given
     when(uacService.findByQid(TEST_QID_ID)).thenReturn(expectedUacQidLink);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
@@ -31,7 +31,6 @@ import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 @ExtendWith(MockitoExtension.class)
 public class ReceiptReceiverTest {
   private static final String QUESTIONNAIRE_ID = "12345";
-  private static final UUID CASE_ID = UUID.randomUUID();
 
   @Mock private UacService uacService;
   @Mock private EventLogger eventLogger;
@@ -127,7 +126,7 @@ public class ReceiptReceiverTest {
   }
 
   @Test
-  public void testUnlinkedUacQidReceiptsUacQidAndCase() {
+  public void testUnlinkedUacQidReceiptsUacQid() {
     ReceiptDTO receiptDTO = new ReceiptDTO();
     receiptDTO.setQid(QUESTIONNAIRE_ID);
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
@@ -24,17 +24,14 @@ import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.ReceiptDTO;
 import uk.gov.ons.ssdc.caseprocessor.service.UacService;
-import uk.gov.ons.ssdc.caseprocessor.utils.MsgDateHelper;
 import uk.gov.ons.ssdc.common.model.entity.EventType;
 import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 
 @ExtendWith(MockitoExtension.class)
 public class ReceiptReceiverTest {
   private static final String QUESTIONNAIRE_ID = "12345";
-  private static final UUID CASE_ID = UUID.randomUUID();
 
   @Mock private UacService uacService;
-  @Mock private CaseService caseService;
   @Mock private EventLogger eventLogger;
 
   @InjectMocks ReceiptReceiver underTest;

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
@@ -41,9 +41,7 @@ public class CaseServiceTest {
     Case caze = new Case();
     caze.setId(UUID.randomUUID());
     caze.setSample(Map.of("foo", "bar"));
-    caze.setReceiptReceived(true);
     caze.setInvalid(true);
-    caze.setEqLaunched(true);
     caze.setRefusalReceived(RefusalType.HARD_REFUSAL);
 
     underTest.saveCaseAndEmitCaseUpdate(caze, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
@@ -61,9 +59,7 @@ public class CaseServiceTest {
     CaseUpdateDTO actualCaseUpdate = actualEvent.getPayload().getCaseUpdate();
     assertThat(actualCaseUpdate.getCaseId()).isEqualTo(caze.getId());
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());
-    assertThat(actualCaseUpdate.isReceiptReceived()).isTrue();
     assertThat(actualCaseUpdate.isInvalid()).isTrue();
-    assertThat(actualCaseUpdate.isEqLaunched()).isTrue();
     assertThat(actualCaseUpdate.getRefusalReceived()).isEqualTo(RefusalTypeDTO.HARD_REFUSAL);
   }
 
@@ -82,9 +78,7 @@ public class CaseServiceTest {
     Case caze = new Case();
     caze.setId(UUID.randomUUID());
     caze.setSample(Map.of("foo", "bar"));
-    caze.setReceiptReceived(true);
     caze.setInvalid(true);
-    caze.setEqLaunched(true);
     caze.setRefusalReceived(RefusalType.EXTRAORDINARY_REFUSAL);
 
     underTest.emitCaseUpdate(caze, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
@@ -101,9 +95,7 @@ public class CaseServiceTest {
     CaseUpdateDTO actualCaseUpdate = actualEvent.getPayload().getCaseUpdate();
     assertThat(actualCaseUpdate.getCaseId()).isEqualTo(caze.getId());
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());
-    assertThat(actualCaseUpdate.isReceiptReceived()).isTrue();
     assertThat(actualCaseUpdate.isInvalid()).isTrue();
-    assertThat(actualCaseUpdate.isEqLaunched()).isTrue();
     assertThat(actualCaseUpdate.getRefusalReceived())
         .isEqualTo(RefusalTypeDTO.EXTRAORDINARY_REFUSAL);
   }


### PR DESCRIPTION
# Motivation and Context
receipted and launched moved from case to uac

# What has changed
receipted and launched moved from case to uac

# How to test?
With others from ticket

# Links
https://trello.com/c/NmU4RIZW/2668-json-schema-v03-release-case-update-receipted-launched-to-be-on-uacupdate-not-caseupdate-8

# Screenshots (if appropriate):
