### PR TITLE
Bump common entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>3.2.2-SNAPSHOT</version>
+      <version>3.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/JunkDataHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/JunkDataHelper.java
@@ -49,6 +49,7 @@ public class JunkDataHelper {
           new ColumnValidator("Junk", false, new Rule[] {new MandatoryRule()})
         });
     junkSurvey.setSampleSeparator('j');
+    junkSurvey.setSampleDefinitionUrl("http://junk");
     surveyRepository.saveAndFlush(junkSurvey);
 
     CollectionExercise junkCollectionExercise = new CollectionExercise();


### PR DESCRIPTION
# Motivation and Context
To comply with [v0.3_RELEASE](https://github.com/ONSdigital/ssdc-shared-events/blob/main/event_dictionary/v0.3_RELEASE/surveyUpdate.schema.json) of the shared events (JSON schema / event dictionary) and to comply with [0.4.0-DRAFT](https://github.com/ONSdigital/ssdc-shared-events/blob/main/event_dictionary/v0.4_RELEASE/surveyUpdate.schema.json) we have to emit `surveyUpdate` events to the `event_survey-update` topic.

# What has changed
Added UI form input sections to allow the users setting up surveys to specify the URL of the sample definition, which should be documented, versioned etc.

Also added input section for metadata.

Then, emitted the event when the survey has been inserted into the database.

# How to test?
Create a survey. Have a look at the `surveyUpdate` event which was emitted.

# Links
Trello: https://trello.com/c/GG73DrrF

# Screenshots (if appropriate):
<img width="1079" alt="Screenshot 2021-10-08 at 15 09 10" src="https://user-images.githubusercontent.com/41681172/136574343-eaad6883-6ccc-4c39-b17c-ff4a70475f12.png">
<img width="622" alt="Screenshot 2021-10-08 at 15 08 32" src="https://user-images.githubusercontent.com/41681172/136574351-e252ce9f-d6ef-40dc-8a4e-26e043c44a5e.png">
<img width="639" alt="Screenshot 2021-10-08 at 15 07 19" src="https://user-images.githubusercontent.com/41681172/136574353-1cbb9378-797e-4c70-b9e1-2ca6ecc2c764.png">
