### PR TITLE
Permit more event versions than just v0.3_RELEASE

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
@@ -1,5 +1,9 @@
 package uk.gov.ons.ssdc.caseprocessor.utils;
 
+import java.util.Set;
+
 public class Constants {
-  public static final String EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
+  public static final String OUTBOUND_EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
+  public static final Set<String> ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS =
+      Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0");
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ssdc.caseprocessor.utils;
 
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -20,7 +20,7 @@ public class EventHelper {
       String originatingUser) {
     EventHeaderDTO eventHeader = new EventHeaderDTO();
 
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setChannel(eventChannel);
     eventHeader.setSource(eventSource);
     eventHeader.setDateTime(OffsetDateTime.now());

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/JsonHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/JsonHelper.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ssdc.caseprocessor.utils;
 
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,11 +26,12 @@ public class JsonHelper {
       throw new RuntimeException(e);
     }
 
-    if (!EVENT_SCHEMA_VERSION.equals(event.getHeader().getVersion())) {
+    if (!ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS.contains((event.getHeader().getVersion()))) {
       throw new RuntimeException(
           String.format(
-              "Incorrect message version. Expected %s but got: %s",
-              EVENT_SCHEMA_VERSION, event.getHeader()));
+              "Unsupported message version. Got %s but RM only supports %s",
+              event.getHeader().getVersion(),
+              String.join(", ", ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS)));
     }
 
     return event;

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +62,7 @@ public class DeactivateUacReceiverIT {
       // GIVEN
       EventDTO event = new EventDTO();
       EventHeaderDTO eventHeader = new EventHeaderDTO();
-      eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(deactivateUacTopic);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/DeactivateUacReceiverTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -42,7 +42,7 @@ public class DeactivateUacReceiverTest {
     // Given
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     managementEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
     managementEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.List;
 import java.util.UUID;
@@ -73,7 +73,7 @@ public class EqLaunchReceiverIT {
 
       EventDTO eqLaunchedEvent = new EventDTO();
       EventHeaderDTO eventHeader = new EventHeaderDTO();
-      eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_TOPIC);
       junkDataHelper.junkify(eventHeader);
       eqLaunchedEvent.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EqLaunchReceiverTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -39,7 +39,7 @@ public class EqLaunchReceiverTest {
   public void testEqLaunchedEventFromRH() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     managementEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
     managementEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_CASE_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,7 +66,7 @@ public class InvalidCaseReceiverIT {
       event.setPayload(payloadDTO);
 
       EventHeaderDTO eventHeader = new EventHeaderDTO();
-      eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_INVALID_CASE_TOPIC);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -41,7 +41,7 @@ public class InvalidCaseReceiverTest {
   public void testInvalidCase() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     managementEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
     managementEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
@@ -3,7 +3,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.NEW_CASE_TOPIC;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_CASE_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.HashMap;
 import java.util.List;
@@ -66,7 +66,7 @@ public class NewCaseReceiverIT {
       // GIVEN
       EventDTO event = new EventDTO();
       EventHeaderDTO eventHeader = new EventHeaderDTO();
-      eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(NEW_CASE_TOPIC);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -79,7 +79,7 @@ public class NewCaseReceiverTest {
     newCase.setSampleSensitive(sampleSensitive);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();
@@ -140,7 +140,7 @@ public class NewCaseReceiverTest {
     newCase.setCaseId(TEST_CASE_ID);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setNewCase(newCase);
 
@@ -170,7 +170,7 @@ public class NewCaseReceiverTest {
     newCase.setCollectionExerciseId(TEST_CASE_COLLECTION_EXERCISE_ID);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setNewCase(newCase);
 
@@ -205,7 +205,7 @@ public class NewCaseReceiverTest {
     newCase.setSampleSensitive(sampleSensitive);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiverTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_UAC_METADATA;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -50,7 +50,7 @@ public class PrintFulfilmentReceiverTest {
     // Given
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));
     managementEvent.getHeader().setTopic("Test topic");
     managementEvent.getHeader().setChannel("CC");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.List;
 import java.util.UUID;
@@ -82,7 +82,7 @@ public class ReceiptReceiverIT {
       event.setPayload(payloadDTO);
 
       EventHeaderDTO eventHeader = new EventHeaderDTO();
-      eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_RECEIPT_TOPIC);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ReceiptReceiverTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -47,7 +47,7 @@ public class ReceiptReceiverTest {
     event.setPayload(payloadDTO);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     eventHeader.setTopic("Test topic");
@@ -91,7 +91,7 @@ public class ReceiptReceiverTest {
     event.setPayload(payloadDTO);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setTopic("Test topic");
     eventHeader.setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
     event.setHeader(eventHeader);
@@ -126,7 +126,7 @@ public class ReceiptReceiverTest {
     event.setPayload(payloadDTO);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     eventHeader.setTopic("Test topic");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_CASE_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +67,7 @@ public class RefusalReceiverIT {
       event.setPayload(payloadDTO);
 
       EventHeaderDTO eventHeader = new EventHeaderDTO();
-      eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_REFUSAL_TOPIC);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -51,7 +51,7 @@ public class RefusalReceiverTest {
     payloadDTO.setRefusal(refusalDTO);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     eventHeader.setTopic("Test topic");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
@@ -3,7 +3,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.SMS_FULFILMENT_TOPIC;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.List;
 import java.util.Map;
@@ -80,7 +80,7 @@ class SmsFulfilmentReceiverIT {
     payloadDTO.setEnrichedSmsFulfilment(enrichedSmsFulfilment);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setTopic(SMS_FULFILMENT_TOPIC);
     junkDataHelper.junkify(eventHeader);
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.Map;
 import java.util.UUID;
@@ -161,7 +161,7 @@ class SmsFulfilmentReceiverTest {
     enrichedSmsFulfilment.setUacMetadata(TEST_UAC_METADATA);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverIT.java
@@ -3,7 +3,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TELEPHONE_CAPTURE_TOPIC;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.List;
 import java.util.UUID;
@@ -75,7 +75,7 @@ class TelephoneCaptureReceiverIT {
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setTelephoneCapture(telephoneCaptureDTO);
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setTopic(TELEPHONE_CAPTURE_TOPIC);
     junkDataHelper.junkify(eventHeader);
     EventDTO event = new EventDTO();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -127,7 +127,7 @@ class TelephoneCaptureReceiverTest {
     telephoneCaptureDTO.setUac(TEST_UAC);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UacAuthenticationReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UacAuthenticationReceiverIT.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.List;
 import java.util.UUID;
@@ -57,7 +57,7 @@ public class UacAuthenticationReceiverIT {
 
     EventDTO eqLaunchedEvent = new EventDTO();
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setTopic(INBOUND_TOPIC);
     junkDataHelper.junkify(eventHeader);
     eqLaunchedEvent.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UacAuthenticationReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UacAuthenticationReceiverTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -41,7 +41,7 @@ public class UacAuthenticationReceiverTest {
   public void testUacAuthentication() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
     managementEvent.getHeader().setTopic("Test topic");
     managementEvent.getHeader().setChannel("RH");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateNewCaseSensitiveReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateNewCaseSensitiveReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_CASE_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -81,7 +81,7 @@ public class UpdateNewCaseSensitiveReceiverIT {
     event.setPayload(payloadDTO);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setTopic(UPDATE_SAMPLE_SENSITIVE_TOPIC);
     junkDataHelper.junkify(eventHeader);
     event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateNewCaseSensitiveReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateNewCaseSensitiveReceiverTest.java
@@ -7,7 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -42,7 +42,7 @@ public class UpdateNewCaseSensitiveReceiverTest {
   public void testUpdateSampleSensitiveReceiver() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));
     managementEvent.getHeader().setTopic("Test topic");
     managementEvent.getHeader().setChannel("CC");
@@ -85,7 +85,7 @@ public class UpdateNewCaseSensitiveReceiverTest {
   public void testMessageKeyDoesNotMatchExistingEntry() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));
     managementEvent.getHeader().setTopic("Test topic");
     managementEvent.getHeader().setChannel("CC");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/FulfilmentIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/FulfilmentIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.schedule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -99,7 +99,7 @@ class FulfilmentIT {
       event.setPayload(payload);
 
       EventHeaderDTO eventHeader = new EventHeaderDTO();
-      eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(FULFILMENT_TOPIC);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelperTest.java
@@ -3,7 +3,7 @@ package uk.gov.ons.ssdc.caseprocessor.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
-import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -17,7 +17,7 @@ public class EventHelperTest {
     EventHeaderDTO eventHeader =
         EventHelper.createEventDTO("TOPIC", TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
 
-    assertThat(eventHeader.getVersion()).isEqualTo(EVENT_SCHEMA_VERSION);
+    assertThat(eventHeader.getVersion()).isEqualTo(OUTBOUND_EVENT_SCHEMA_VERSION);
     assertThat(eventHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);
     assertThat(eventHeader.getOriginatingUser()).isEqualTo(TEST_ORIGINATING_USER);
     assertThat(eventHeader.getTopic()).isEqualTo("TOPIC");
@@ -33,7 +33,7 @@ public class EventHelperTest {
         EventHelper.createEventDTO(
             "TOPIC", "CHANNEL", "SOURCE", TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
 
-    assertThat(eventHeader.getVersion()).isEqualTo(EVENT_SCHEMA_VERSION);
+    assertThat(eventHeader.getVersion()).isEqualTo(OUTBOUND_EVENT_SCHEMA_VERSION);
     assertThat(eventHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);
     assertThat(eventHeader.getOriginatingUser()).isEqualTo(TEST_ORIGINATING_USER);
     assertThat(eventHeader.getChannel()).isEqualTo("CHANNEL");


### PR DESCRIPTION
# Motivation and Context
We don't quite know what version INT will be sending to us when we meet in integration, so let's be a bit more permsisive.

# What has changed
Allow `0.4.0-DRAFT` and `0.4.0` as versions, as well as `v0.3_RELEASE`.

# How to test?
Wang in some messages with `0.4.0-DRAFT` or `0.4.0` version in the header, and check they're not rejected.

# Links
Trello: https://trello.com/c/i1kSq2Sz