### PR TITLE
Emit survey & collex ID on case update

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
@@ -7,6 +7,8 @@ import lombok.Data;
 @Data
 public class CaseUpdateDTO {
   private UUID caseId;
+  private UUID collectionExerciseId;
+  private UUID surveyId;
   private boolean invalid;
   private RefusalTypeDTO refusalReceived;
   private Map<String, String> sample;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -55,6 +55,8 @@ public class CaseService {
     PayloadDTO payloadDTO = new PayloadDTO();
     CaseUpdateDTO caseUpdate = new CaseUpdateDTO();
     caseUpdate.setCaseId(caze.getId());
+    caseUpdate.setCollectionExerciseId(caze.getCollectionExercise().getId());
+    caseUpdate.setSurveyId(caze.getCollectionExercise().getSurvey().getId());
     caseUpdate.setSample(caze.getSample());
     caseUpdate.setInvalid(caze.isInvalid());
     if (caze.getRefusalReceived() != null) {

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
@@ -96,6 +96,10 @@ public class NewCaseReceiverIT {
 
       CaseUpdateDTO emittedCase = actualEvent.getPayload().getCaseUpdate();
       Assertions.assertThat(emittedCase.getCaseId()).isEqualTo(TEST_CASE_ID);
+      Assertions.assertThat(emittedCase.getCollectionExerciseId())
+          .isEqualTo(collectionExercise.getId());
+      Assertions.assertThat(emittedCase.getSurveyId())
+          .isEqualTo(collectionExercise.getSurvey().getId());
 
       Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
@@ -24,7 +24,9 @@ import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.RefusalTypeDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.CaseRepository;
 import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
 import uk.gov.ons.ssdc.common.model.entity.RefusalType;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 @ExtendWith(MockitoExtension.class)
 public class CaseServiceTest {
@@ -38,8 +40,15 @@ public class CaseServiceTest {
     ReflectionTestUtils.setField(underTest, "caseUpdateTopic", "Test topic");
     ReflectionTestUtils.setField(underTest, "sharedPubsubProject", "Test project");
 
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    CollectionExercise collex = new CollectionExercise();
+    collex.setId(UUID.randomUUID());
+    collex.setSurvey(survey);
+
     Case caze = new Case();
     caze.setId(UUID.randomUUID());
+    caze.setCollectionExercise(collex);
     caze.setSample(Map.of("foo", "bar"));
     caze.setInvalid(true);
     caze.setRefusalReceived(RefusalType.HARD_REFUSAL);
@@ -58,6 +67,8 @@ public class CaseServiceTest {
 
     CaseUpdateDTO actualCaseUpdate = actualEvent.getPayload().getCaseUpdate();
     assertThat(actualCaseUpdate.getCaseId()).isEqualTo(caze.getId());
+    assertThat(actualCaseUpdate.getCollectionExerciseId()).isEqualTo(collex.getId());
+    assertThat(actualCaseUpdate.getSurveyId()).isEqualTo(survey.getId());
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());
     assertThat(actualCaseUpdate.isInvalid()).isTrue();
     assertThat(actualCaseUpdate.getRefusalReceived()).isEqualTo(RefusalTypeDTO.HARD_REFUSAL);
@@ -75,8 +86,15 @@ public class CaseServiceTest {
     ReflectionTestUtils.setField(underTest, "caseUpdateTopic", "Test topic");
     ReflectionTestUtils.setField(underTest, "sharedPubsubProject", "Test project");
 
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    CollectionExercise collex = new CollectionExercise();
+    collex.setId(UUID.randomUUID());
+    collex.setSurvey(survey);
+
     Case caze = new Case();
     caze.setId(UUID.randomUUID());
+    caze.setCollectionExercise(collex);
     caze.setSample(Map.of("foo", "bar"));
     caze.setInvalid(true);
     caze.setRefusalReceived(RefusalType.EXTRAORDINARY_REFUSAL);


### PR DESCRIPTION
# Motivation and Context
To comply with [v0.3_RELEASE](https://github.com/ONSdigital/ssdc-shared-events/blob/main/event_dictionary/v0.3_RELEASE/caseUpdate.schema.json) of the JSON schema, we need to emit the collex and survey ID on `caseUpdate` events.

# What has changed
Added the things.

# How to test?
Run the tests.

# Links
Trello: https://trello.com/c/Poo1IAvS