### PR TITLE
Disallow attempts to send RM sensitive data not defined in sample

### DIFF
--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
@@ -78,7 +78,7 @@ public class NewCaseReceiverIT {
       sample.put("Org", "Brewery");
 
       Map<String, String> sampleSensitive = new HashMap<>();
-      sampleSensitive.put("Telephone", "02071234567");
+      sampleSensitive.put("SensitiveJunk", "02071234567");
 
       PayloadDTO payloadDTO = new PayloadDTO();
       NewCase newCase = new NewCase();
@@ -107,7 +107,7 @@ public class NewCaseReceiverIT {
       List<Event> events = eventRepository.findAll();
       assertThat(events.size()).isEqualTo(1);
       assertThat(events.get(0).getType()).isEqualTo(EventType.NEW_CASE);
-      assertThat(events.get(0).getPayload()).contains("{\"Telephone\": \"REDACTED\"}");
+      assertThat(events.get(0).getPayload()).contains("{\"SensitiveJunk\": \"REDACTED\"}");
     }
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverTest.java
@@ -164,6 +164,8 @@ public class NewCaseReceiverTest {
 
   @Test
   public void testNewCaseReceiverCollectionExerciseNotFound() {
+    ReflectionTestUtils.setField(underTest, "caserefgeneratorkey", caserefgeneratorkey);
+
     // Given
     NewCase newCase = new NewCase();
     newCase.setCaseId(TEST_CASE_ID);
@@ -190,6 +192,8 @@ public class NewCaseReceiverTest {
 
   @Test
   public void testNewCaseReceiverCaseFailsValidation() {
+    ReflectionTestUtils.setField(underTest, "caserefgeneratorkey", caserefgeneratorkey);
+
     // Given
     NewCase newCase = new NewCase();
     newCase.setCaseId(TEST_CASE_ID);
@@ -202,6 +206,60 @@ public class NewCaseReceiverTest {
 
     Map<String, String> sampleSensitive = new HashMap<>();
     sampleSensitive.put("Telephone", "020712345");
+    newCase.setSampleSensitive(sampleSensitive);
+
+    EventHeaderDTO eventHeader = new EventHeaderDTO();
+    eventHeader.setVersion(EVENT_SCHEMA_VERSION);
+    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
+    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setNewCase(newCase);
+
+    EventDTO event = new EventDTO();
+    event.setHeader(eventHeader);
+    event.setPayload(payloadDTO);
+
+    Message<byte[]> eventMessage = constructMessage(event);
+
+    when(caseRepository.existsById(TEST_CASE_ID)).thenReturn(false);
+
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    survey.setSampleValidationRules(
+        new ColumnValidator[] {
+          new ColumnValidator("ADDRESS_LINE1", false, new Rule[] {new MandatoryRule()}),
+          new ColumnValidator(
+              "POSTCODE", false, new Rule[] {new MandatoryRule(), new LengthRule(8)}),
+          new ColumnValidator("Telephone", true, new Rule[] {new MandatoryRule()})
+        });
+
+    CollectionExercise collex = new CollectionExercise();
+    collex.setSurvey(survey);
+    Optional<CollectionExercise> collexOpt = Optional.of(collex);
+
+    when(collectionExerciseRepository.findById(TEST_CASE_COLLECTION_EXERCISE_ID))
+        .thenReturn(collexOpt);
+
+    assertThrows(RuntimeException.class, () -> underTest.receiveNewCase(eventMessage));
+    verifyNoInteractions(eventLogger);
+  }
+
+  @Test
+  public void testNewCaseReceiverCaseFailsValidationBecauseOfUndefinedSensitiveData() {
+    ReflectionTestUtils.setField(underTest, "caserefgeneratorkey", caserefgeneratorkey);
+
+    // Given
+    NewCase newCase = new NewCase();
+    newCase.setCaseId(TEST_CASE_ID);
+    newCase.setCollectionExerciseId(TEST_CASE_COLLECTION_EXERCISE_ID);
+
+    Map<String, String> sample = new HashMap<>();
+    sample.put("ADDRESS_LINE1", "123 Fake Street");
+    sample.put("POSTCODE", "abc123");
+    newCase.setSample(sample);
+
+    Map<String, String> sampleSensitive = new HashMap<>();
+    sampleSensitive.put("EmailAdddress", "foo@bar.baz");
     newCase.setSampleSensitive(sampleSensitive);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/JunkDataHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/JunkDataHelper.java
@@ -46,7 +46,8 @@ public class JunkDataHelper {
     junkSurvey.setName("Junk survey");
     junkSurvey.setSampleValidationRules(
         new ColumnValidator[] {
-          new ColumnValidator("Junk", false, new Rule[] {new MandatoryRule()})
+          new ColumnValidator("Junk", false, new Rule[] {new MandatoryRule()}),
+          new ColumnValidator("SensitiveJunk", true, new Rule[] {new MandatoryRule()})
         });
     junkSurvey.setSampleSeparator('j');
     surveyRepository.saveAndFlush(junkSurvey);


### PR DESCRIPTION
# Motivation and Context
Other products might try to send RM sensitive data which is not part of the sample definition. We should explicitly disallow this, because there would be no mechanism to update/remove it.

# What has changed
Check for unexpected data and reject it.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/89DC0oPU