### PR TITLE
Allow simultaneous builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 before_install:
   - mvn fmt:check
   - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  - docker network create ssdcrmdockerdev_default
   - echo "$DOCKER_GCP_PASSWORD" > ~/google-service-account-key.json
   - export GOOGLE_APPLICATION_CREDENTIALS=~/google-service-account-key.json
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.9.1</version>
         <executions>
           <execution>
             <goals>

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:15432/postgres
+    url: jdbc:postgresql://localhost:16432/postgres
 
   cloud:
     gcp:

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-dev-common-postgres:latest
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
     ports:
-      - "15432:5432"
+      - "16432:5432"
 
   uac-qid-case-it:
     container_name: uac-qid-case-it
@@ -45,3 +45,8 @@ services:
     depends_on:
       uac-qid-case-it:
         condition: service_healthy
+
+networks:
+  default:
+    external:
+      name: ssdcrmdockerdev_default

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '2.1'
 services:
-  postgres:
+  postgres-case-it:
     container_name: postgres-case-it
     image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-dev-common-postgres:latest
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
     ports:
       - "15432:5432"
 
-  uac-qid:
+  uac-qid-case-it:
     container_name: uac-qid-case-it
     image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-uac-qid-service:latest
     ports:
@@ -23,24 +23,25 @@ services:
       timeout: 10s
       retries: 10
 
-  pubsub-emulator:
+  pubsub-emulator-case-it:
     container_name: pubsub-emulator-case-it
     image: eu.gcr.io/ssdc-rm-ci/rm/gcloud-pubsub-emulator:latest
     ports:
       - "18538:8538"
 
-  setup-pubsub-emulator:
+  setup-pubsub-emulator-case-it:
+    container_name: setup-pubsub-emulator-case-it
     image: eu.gcr.io/ssdc-rm-ci/rm/gcloud-pubsub-emulator:latest
     environment:
-      - PUBSUB_SETUP_HOST=pubsub-emulator:8538
+      - PUBSUB_SETUP_HOST=pubsub-emulator-case-it:8538
     volumes:
       - ./setup_pubsub.sh:/setup_pubsub.sh
     depends_on:
-      - pubsub-emulator
+      - pubsub-emulator-case-it
     entrypoint: sh -c "/setup_pubsub.sh"
 
   start_dependencies:
     image: dadarek/wait-for-dependencies
     depends_on:
-      uac-qid:
+      uac-qid-case-it:
         condition: service_healthy


### PR DESCRIPTION
# Motivation and Context
The Docker containers needed to make the integration tests clash with each other on ports, so can't be run at the same time as other projects/repos.

# What has changed
Juggled the ports around to make them independent. Also, other fiddly stuff so that all the images/containers don't clash.

# How to test?
Try building two or more projects at the same time, and it should work with no problems.

# Links
Trello: https://trello.com/c/4FrIJ1LW