### PR TITLE
2970 Sanitize validation error messages 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	mvn clean install
+
+build_no_test:
+	mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiver.java
@@ -78,7 +78,7 @@ public class NewCaseReceiver {
       }
 
       if (columnValidationErrors.isPresent()) {
-        throw new RuntimeException(columnValidationErrors.get());
+        throw new RuntimeException("New Case failed validation");
       }
     }
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateNewCaseSensitiveReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateNewCaseSensitiveReceiverTest.java
@@ -37,7 +37,7 @@ import uk.gov.ons.ssdc.common.validation.LengthRule;
 import uk.gov.ons.ssdc.common.validation.Rule;
 
 @ExtendWith(MockitoExtension.class)
-public class UpdateNewCaseSensitiveReceiverTest {
+class UpdateNewCaseSensitiveReceiverTest {
 
   @Mock private CaseService caseService;
   @Mock private EventLogger eventLogger;
@@ -45,7 +45,7 @@ public class UpdateNewCaseSensitiveReceiverTest {
   @InjectMocks UpdateSampleSensitiveReceiver underTest;
 
   @Test
-  public void testUpdateSampleSensitiveReceiver() {
+  void testUpdateSampleSensitiveReceiver() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
     managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
@@ -99,7 +99,7 @@ public class UpdateNewCaseSensitiveReceiverTest {
   }
 
   @Test
-  public void testUpdateSampleSensitiveReceiverBlankingIsAllowed() {
+  void testUpdateSampleSensitiveReceiverBlankingIsAllowed() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
     managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
@@ -153,7 +153,7 @@ public class UpdateNewCaseSensitiveReceiverTest {
   }
 
   @Test
-  public void testMessageKeyDoesNotMatchExistingEntry() {
+  void testMessageKeyDoesNotMatchExistingEntry() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
     managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
@@ -184,7 +184,7 @@ public class UpdateNewCaseSensitiveReceiverTest {
   }
 
   @Test
-  public void testUpdateSampleSensitiveReceiverFailsValidation() {
+  void testUpdateSampleSensitiveReceiverFailsValidation() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
     managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);


### PR DESCRIPTION
# Motivation and Context
Avoid using the helpful but risky bespoke validation error logging, it may leak data into logs. Use a generic "validation failed" message instead.

# What has changed
- Replace bespoke validation error message
- Small housekeeping changes

# How to test?
Post in some new cases or update sample sensitive messages with data which fails validation, the exception message logged should now be generic and less helpful but with no risk of leaking data.

# Links
https://trello.com/c/lNPldLJI/2970-tweak-validation-errors-output-for-sensitive-data-5