### PR TITLE
Disallow any attempts to add sample data which was not defined

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiver.java
@@ -38,8 +38,8 @@ public class UpdateSampleReceiver {
     Case caze = caseService.getCaseByCaseId(updateSample.getCaseId());
 
     for (Map.Entry<String, String> entry : updateSample.getSample().entrySet()) {
-      // Validate that only non-sensitive sample data is being attempted to be updated
-      validateOnlyNonSensitiveSampleDataBeingUpdated(caze, entry);
+      // Validate that only existing sample data is being attempted to be updated
+      validateOnlyExistingSampleDataBeingUpdated(caze, entry);
 
       // Validate the updated value according to the rules for the column
       for (ColumnValidator columnValidator :
@@ -56,16 +56,10 @@ public class UpdateSampleReceiver {
     eventLogger.logCaseEvent(caze, "Sample data updated", EventType.UPDATE_SAMPLE, event, message);
   }
 
-  private void validateOnlyNonSensitiveSampleDataBeingUpdated(
-      Case caze, Entry<String, String> entry) {
-    if (caze.getSampleSensitive() != null
-        && caze.getSampleSensitive().containsKey(entry.getKey())) {
+  private void validateOnlyExistingSampleDataBeingUpdated(Case caze, Entry<String, String> entry) {
+    if (!caze.getSample().containsKey(entry.getKey())) {
       throw new RuntimeException(
-          "Key ("
-              + entry.getKey()
-              + ") is sensitive and cannot be used for non-sensitive "
-              + EventType.UPDATE_SAMPLE
-              + " events!");
+          "Key (" + entry.getKey() + ") does not match existing sample data");
     }
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverIT.java
@@ -75,7 +75,6 @@ public class NewCaseReceiverIT {
 
       Map<String, String> sample = new HashMap<>();
       sample.put("Junk", "YesYouCan");
-      sample.put("Org", "Brewery");
 
       Map<String, String> sampleSensitive = new HashMap<>();
       sampleSensitive.put("SensitiveJunk", "02071234567");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverTest.java
@@ -47,57 +47,6 @@ public class UpdateSampleReceiverTest {
   @InjectMocks UpdateSampleReceiver underTest;
 
   @Test
-  void testUpdateSampleReceiverCreatesNewSampleData() {
-    EventDTO managementEvent = new EventDTO();
-    managementEvent.setHeader(new EventHeaderDTO());
-    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
-    managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));
-    managementEvent.getHeader().setTopic("Test topic");
-    managementEvent.getHeader().setChannel("CC");
-    managementEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
-    managementEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
-    managementEvent.setPayload(new PayloadDTO());
-    managementEvent.getPayload().setUpdateSample(new UpdateSample());
-    managementEvent.getPayload().getUpdateSample().setCaseId(UUID.randomUUID());
-    managementEvent.getPayload().getUpdateSample().setSample(Map.of("newSampleData", "New"));
-    Message<byte[]> message = constructMessage(managementEvent);
-
-    // Given
-    Survey survey = new Survey();
-    survey.setId(UUID.randomUUID());
-    survey.setSampleValidationRules(
-        new ColumnValidator[] {
-          new ColumnValidator("newSampleData", false, new Rule[] {new LengthRule(30)})
-        });
-    CollectionExercise collex = new CollectionExercise();
-    collex.setId(UUID.randomUUID());
-    collex.setSurvey(survey);
-
-    Case expectedCase = new Case();
-    expectedCase.setCollectionExercise(collex);
-    expectedCase.setSample(new HashMap<>()); // No sample data
-    expectedCase.setSampleSensitive(new HashMap<>());
-
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
-
-    // when
-    underTest.receiveMessage(message);
-
-    // then
-    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-
-    verify(caseService)
-        .saveCaseAndEmitCaseUpdate(
-            caseArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
-    Case actualCase = caseArgumentCaptor.getValue();
-    assertThat(actualCase.getSample()).isEqualTo(Map.of("newSampleData", "New"));
-
-    verify(eventLogger)
-        .logCaseEvent(
-            expectedCase, "Sample data updated", EventType.UPDATE_SAMPLE, managementEvent, message);
-  }
-
-  @Test
   void testUpdateSampleReceiverUpdatesExistingSampleData() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
@@ -151,6 +100,36 @@ public class UpdateSampleReceiverTest {
   }
 
   @Test
+  void testCannotUpdateSampleReceiverCreateNewSampleData() {
+    EventDTO managementEvent = new EventDTO();
+    managementEvent.setHeader(new EventHeaderDTO());
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")).minusHours(1));
+    managementEvent.getHeader().setTopic("Test topic");
+    managementEvent.getHeader().setChannel("CC");
+    managementEvent.setPayload(new PayloadDTO());
+    managementEvent.getPayload().setUpdateSample(new UpdateSample());
+    managementEvent.getPayload().getUpdateSample().setCaseId(UUID.randomUUID());
+    managementEvent.getPayload().getUpdateSample().setSample(Map.of("newThing", "abc123"));
+    Message<byte[]> message = constructMessage(managementEvent);
+
+    // Given
+    Case expectedCase = new Case();
+    Map<String, String> existingSampleData = new HashMap<>();
+    existingSampleData.put("testThing", "xyz666");
+    expectedCase.setSample(existingSampleData);
+    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+
+    // When, then throws
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> underTest.receiveMessage(message));
+    assertThat(thrown.getMessage()).isEqualTo("Key (newThing) does not match existing sample data");
+
+    verify(caseService, never()).saveCaseAndEmitCaseUpdate(any(), any(), any());
+    verify(eventLogger, never()).logCaseEvent(any(), any(), any(), any(), any(Message.class));
+  }
+
+  @Test
   void testCannotUseUpdateSampleMessageKeyOnExistingSensitiveKey() {
     EventDTO managementEvent = new EventDTO();
     managementEvent.setHeader(new EventHeaderDTO());
@@ -161,11 +140,15 @@ public class UpdateSampleReceiverTest {
     managementEvent.setPayload(new PayloadDTO());
     managementEvent.getPayload().setUpdateSample(new UpdateSample());
     managementEvent.getPayload().getUpdateSample().setCaseId(UUID.randomUUID());
+    managementEvent.getPayload().getUpdateSample().setSample(Map.of("testThing", "abc123"));
     managementEvent.getPayload().getUpdateSample().setSample(Map.of("mobileNumber", "999999999"));
     Message<byte[]> message = constructMessage(managementEvent);
 
     // Given
     Case expectedCase = new Case();
+    Map<String, String> existingSampleData = new HashMap<>();
+    existingSampleData.put("testThing", "xyz666");
+    expectedCase.setSample(existingSampleData);
     Map<String, String> existingSensitiveSampleData = new HashMap<>();
     existingSensitiveSampleData.put("mobileNumber", "111111111");
     expectedCase.setSampleSensitive(existingSensitiveSampleData);
@@ -175,8 +158,7 @@ public class UpdateSampleReceiverTest {
     RuntimeException thrown =
         assertThrows(RuntimeException.class, () -> underTest.receiveMessage(message));
     assertThat(thrown.getMessage())
-        .isEqualTo(
-            "Key (mobileNumber) is sensitive and cannot be used for non-sensitive UPDATE_SAMPLE events!");
+        .isEqualTo("Key (mobileNumber) does not match existing sample data");
 
     verify(caseService, never()).saveCaseAndEmitCaseUpdate(any(), any(), any());
     verify(eventLogger, never()).logCaseEvent(any(), any(), any(), any(), any(Message.class));


### PR DESCRIPTION
# Motivation and Context
RM's flexible JSON-based sample data storage has the capability of storing just about any sample data that might be sent our way, but the question is: _should_ we store any unexpected sample data? It might contain sensitive data. It might not be validated. It might be masking a bug in the sending application. Safer to just reject it.

# What has changed
Disallow anything other than exactly what's in the sample definition of the survey, on `newCase` and `updateSample` events.

# How to test?
Try sending in `newCase` and `updateSample` events with extra stuff.

# Links
Trello: https://trello.com/c/PuCl0ZJP