### PR TITLE
Add and Redact SampleSensitive to caseUpdated Events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
   </repositories>
 
   <dependencies>
-    
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
@@ -12,4 +12,5 @@ public class CaseUpdateDTO {
   private boolean invalid;
   private RefusalTypeDTO refusalReceived;
   private Map<String, String> sample;
+  private Map<String, String> sampleSensitive;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -14,6 +14,7 @@ import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.RefusalTypeDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.CaseRepository;
 import uk.gov.ons.ssdc.caseprocessor.utils.EventHelper;
+import uk.gov.ons.ssdc.caseprocessor.utils.RedactHelper;
 import uk.gov.ons.ssdc.common.model.entity.Case;
 
 @Service
@@ -58,12 +59,20 @@ public class CaseService {
     caseUpdate.setCollectionExerciseId(caze.getCollectionExercise().getId());
     caseUpdate.setSurveyId(caze.getCollectionExercise().getSurvey().getId());
     caseUpdate.setSample(caze.getSample());
+
     caseUpdate.setInvalid(caze.isInvalid());
     if (caze.getRefusalReceived() != null) {
       caseUpdate.setRefusalReceived(RefusalTypeDTO.valueOf(caze.getRefusalReceived().name()));
     } else {
       caseUpdate.setRefusalReceived(null);
     }
+    caseUpdate.setSampleSensitive(caze.getSampleSensitive());
+
+    // Due to time taken only run this is there's sampleSensitive data on the case
+    if (caseUpdate.getSampleSensitive() != null) {
+      caseUpdate = (CaseUpdateDTO) RedactHelper.redact(caseUpdate);
+    }
+
     payloadDTO.setCaseUpdate(caseUpdate);
     EventDTO event = new EventDTO();
     event.setHeader(eventHeader);

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -68,7 +68,6 @@ public class CaseService {
     }
     caseUpdate.setSampleSensitive(caze.getSampleSensitive());
 
-    // Due to time taken only run this is there's sampleSensitive data on the case
     if (caseUpdate.getSampleSensitive() != null) {
       caseUpdate = (CaseUpdateDTO) RedactHelper.redact(caseUpdate);
     }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
@@ -50,6 +50,7 @@ public class CaseServiceTest {
     caze.setId(UUID.randomUUID());
     caze.setCollectionExercise(collex);
     caze.setSample(Map.of("foo", "bar"));
+    caze.setSampleSensitive(Map.of("Top", "Secret"));
     caze.setInvalid(true);
     caze.setRefusalReceived(RefusalType.HARD_REFUSAL);
 
@@ -72,6 +73,7 @@ public class CaseServiceTest {
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());
     assertThat(actualCaseUpdate.isInvalid()).isTrue();
     assertThat(actualCaseUpdate.getRefusalReceived()).isEqualTo(RefusalTypeDTO.HARD_REFUSAL);
+    assertThat(actualCaseUpdate.getSampleSensitive()).isEqualTo(Map.of("Top", "REDACTED"));
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
Emit redacted sensitive data on case update

# What has changed
Adds sensitive data and.... redacts it

# How to test?
Run the tests, run the ATs on the ticket

# Links
https://trello.com/c/3ZKcJtYK/3012-sensitive-data-to-be-included-on-case-update-event-but-redacted-5
