### PR TITLE
Add email functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.4.0-SNAPSHOT</version>
+      <version>4.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
@@ -58,6 +58,9 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.sms-fulfilment-subscription}")
   private String smsFulfilmentSubscription;
 
+  @Value("${queueconfig.email-fulfilment-subscription}")
+  private String emailFulfilmentSubscription;
+
   public MessageConsumerConfig(
       ManagedMessageRecoverer managedMessageRecoverer, PubSubTemplate pubSubTemplate) {
     this.managedMessageRecoverer = managedMessageRecoverer;
@@ -121,6 +124,11 @@ public class MessageConsumerConfig {
 
   @Bean
   public MessageChannel smsFulfilmentInputChannel() {
+    return new DirectChannel();
+  }
+
+  @Bean
+  public MessageChannel emailFulfilmentInputChannel() {
     return new DirectChannel();
   }
 
@@ -215,6 +223,12 @@ public class MessageConsumerConfig {
   PubSubInboundChannelAdapter smsFulfilmentInbound(
       @Qualifier("smsFulfilmentInputChannel") MessageChannel channel) {
     return makeAdapter(channel, smsFulfilmentSubscription);
+  }
+
+  @Bean
+  PubSubInboundChannelAdapter emailFulfilmentInbound(
+      @Qualifier("emailFulfilmentInputChannel") MessageChannel channel) {
+    return makeAdapter(channel, emailFulfilmentSubscription);
   }
 
   private PubSubInboundChannelAdapter makeAdapter(MessageChannel channel, String subscriptionName) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiver.java
@@ -1,0 +1,72 @@
+package uk.gov.ons.ssdc.caseprocessor.messaging;
+
+import static uk.gov.ons.ssdc.caseprocessor.utils.JsonHelper.convertJsonBytesToEvent;
+
+import org.springframework.integration.annotation.MessageEndpoint;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.Message;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EnrichedEmailFulfilment;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.ssdc.caseprocessor.service.CaseService;
+import uk.gov.ons.ssdc.caseprocessor.service.UacService;
+import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.EventType;
+import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
+
+@MessageEndpoint
+public class EmailFulfilmentReceiver {
+
+  private final UacService uacService;
+  private final CaseService caseService;
+  private final EventLogger eventLogger;
+
+  private static final String EMAIL_FULFILMENT_DESCRIPTION = "Email fulfilment request received";
+
+  public EmailFulfilmentReceiver(
+      UacService uacService, CaseService caseService, EventLogger eventLogger) {
+    this.uacService = uacService;
+    this.caseService = caseService;
+    this.eventLogger = eventLogger;
+  }
+
+  @Transactional
+  @ServiceActivator(inputChannel = "emailFulfilmentInputChannel", adviceChain = "retryAdvice")
+  public void receiveMessage(Message<byte[]> message) {
+    EventDTO event = convertJsonBytesToEvent(message.getPayload());
+    EnrichedEmailFulfilment emailFulfilment = event.getPayload().getEnrichedEmailFulfilment();
+
+    Case caze = caseService.getCaseByCaseId(emailFulfilment.getCaseId());
+
+    if (emailFulfilment.getQid() != null) {
+      // Check the QID does not already exist
+      if (uacService.existsByQid(emailFulfilment.getQid())) {
+
+        // If it does exist, check if it is linked to the given case
+        UacQidLink existingUacQidLink = uacService.findByQid(emailFulfilment.getQid());
+        if (existingUacQidLink.getCaze().getId().equals(emailFulfilment.getCaseId())) {
+
+          // If the QID is already linked to the given case this must be duplicate event, ignore
+          return;
+        }
+
+        // If not then something has gone wrong, error out
+        throw new RuntimeException(
+            "Email fulfilment QID "
+                + emailFulfilment.getQid()
+                + " is already linked to a different case");
+      }
+      uacService.createLinkAndEmitNewUacQid(
+          caze,
+          emailFulfilment.getUac(),
+          emailFulfilment.getQid(),
+          emailFulfilment.getUacMetadata(),
+          event.getHeader().getCorrelationId(),
+          event.getHeader().getOriginatingUser());
+    }
+
+    eventLogger.logCaseEvent(
+        caze, EMAIL_FULFILMENT_DESCRIPTION, EventType.EMAIL_FULFILMENT, event, message);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailRequest.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailRequest.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ssdc.caseprocessor.model.dto;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class EmailRequest {
+  private UUID caseId;
+
+  private String email;
+
+  private String packCode;
+
+  private Object uacMetadata;
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EnrichedEmailFulfilment.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EnrichedEmailFulfilment.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ssdc.caseprocessor.model.dto;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class EnrichedEmailFulfilment {
+  private UUID caseId;
+  private String packCode;
+  private String uac;
+  private String qid;
+  private Object uacMetadata;
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
@@ -20,6 +20,8 @@ public class PayloadDTO {
   private EqLaunchDTO eqLaunch;
   private UacAuthenticationDTO uacAuthentication;
   private EnrichedSmsFulfilment enrichedSmsFulfilment;
+  private EnrichedEmailFulfilment enrichedEmailFulfilment;
   private NewCase newCase;
   private SmsRequest smsRequest;
+  private EmailRequest emailRequest;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
@@ -12,14 +12,17 @@ public class CaseToProcessProcessor {
   private final ExportFileProcessor exportFileProcessor;
   private final DeactivateUacProcessor deactivateUacProcessor;
   private final SmsProcessor smsProcessor;
+  private final EmailProcessor emailProcessor;
 
   public CaseToProcessProcessor(
       ExportFileProcessor exportFileProcessor,
       DeactivateUacProcessor deactivateUacProcessor,
-      SmsProcessor smsProcessor) {
+      SmsProcessor smsProcessor,
+      EmailProcessor emailProcessor) {
     this.exportFileProcessor = exportFileProcessor;
     this.deactivateUacProcessor = deactivateUacProcessor;
     this.smsProcessor = smsProcessor;
+    this.emailProcessor = emailProcessor;
   }
 
   public void process(CaseToProcess caseToProcess) {
@@ -45,6 +48,9 @@ public class CaseToProcessProcessor {
         break;
       case SMS:
         smsProcessor.process(caseToProcess.getCaze(), caseToProcess.getActionRule());
+        break;
+      case EMAIL:
+        emailProcessor.process(caseToProcess.getCaze(), caseToProcess.getActionRule());
         break;
       default:
         throw new NotImplementedException("No implementation for other types of action rule yet");

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EmailProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EmailProcessor.java
@@ -1,0 +1,61 @@
+package uk.gov.ons.ssdc.caseprocessor.service;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
+import uk.gov.ons.ssdc.caseprocessor.messaging.MessageSender;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EmailRequest;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.ssdc.caseprocessor.utils.EventHelper;
+import uk.gov.ons.ssdc.common.model.entity.ActionRule;
+import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.EventType;
+
+@Component
+public class EmailProcessor {
+  private final MessageSender messageSender;
+  private final EventLogger eventLogger;
+
+  @Value("${queueconfig.email-request-topic}")
+  private String emailRequestTopic;
+
+  public EmailProcessor(MessageSender messageSender, EventLogger eventLogger) {
+    this.messageSender = messageSender;
+    this.eventLogger = eventLogger;
+  }
+
+  public void process(Case caze, ActionRule actionRule) {
+    UUID caseId = caze.getId();
+    String packCode = actionRule.getEmailTemplate().getPackCode();
+    String email = caze.getSampleSensitive().get(actionRule.getEmailColumn());
+
+    EmailRequest emailRequest = new EmailRequest();
+    emailRequest.setCaseId(caseId);
+    emailRequest.setPackCode(packCode);
+    emailRequest.setEmail(email);
+    emailRequest.setUacMetadata(actionRule.getUacMetadata());
+
+    EventHeaderDTO eventHeader =
+        EventHelper.createEventDTO(
+            emailRequestTopic, actionRule.getId(), actionRule.getCreatedBy());
+
+    EventDTO event = new EventDTO();
+    PayloadDTO payload = new PayloadDTO();
+    event.setHeader(eventHeader);
+    event.setPayload(payload);
+    payload.setEmailRequest(emailRequest);
+
+    messageSender.sendMessage(emailRequestTopic, event);
+
+    eventLogger.logCaseEvent(
+        caze,
+        String.format("Email requested by action rule for pack code %s", packCode),
+        EventType.ACTION_RULE_EMAIL_REQUEST,
+        event,
+        OffsetDateTime.now());
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/RedactHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/RedactHelper.java
@@ -20,7 +20,8 @@ public class RedactHelper {
   private static final ThingToRedact[] THINGS_TO_REDACT = {
     new ThingToRedact("getSampleSensitive", Map.class),
     new ThingToRedact("setUac", String.class),
-    new ThingToRedact("setPhoneNumber", String.class)
+    new ThingToRedact("setPhoneNumber", String.class),
+    new ThingToRedact("setEmail", String.class)
   };
 
   public static Object redact(Object rootObjectToRedact) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,7 @@ spring:
 queueconfig:
   telephone-capture-subscription: rm-internal-telephone-capture_case-processor
   sms-fulfilment-subscription: rm-internal-sms-fulfilment_case-processor
+  email-fulfilment-subscription: rm-internal-email-fulfilment_case-processor
   new-case-subscription: event_new-case_rm-case-processor
   receipt-subscription: event_receipt_rm-case-processor
   refusal-subscription: event_refusal_rm-case-processor
@@ -50,6 +51,7 @@ queueconfig:
   update-sample-subscription: event_update-sample_rm-case-processor
   update-sample-sensitive-subscription: event_update-sample-sensitive_rm-case-processor
   sms-request-topic: rm-internal-sms-request
+  email-request-topic: rm-internal-email-request
   case-update-topic: event_case-update
   uac-update-topic: event_uac-update
   deactivate-uac-topic: event_deactivate-uac

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
@@ -1,0 +1,109 @@
+package uk.gov.ons.ssdc.caseprocessor.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.EMAIL_FULFILMENT_TOPIC;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.ons.ssdc.caseprocessor.client.UacQidServiceClient;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EnrichedEmailFulfilment;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.UacQidDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.UacUpdateDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.repository.UacQidLinkRepository;
+import uk.gov.ons.ssdc.caseprocessor.testutils.DeleteDataHelper;
+import uk.gov.ons.ssdc.caseprocessor.testutils.JunkDataHelper;
+import uk.gov.ons.ssdc.caseprocessor.testutils.PubsubHelper;
+import uk.gov.ons.ssdc.caseprocessor.testutils.QueueSpy;
+import uk.gov.ons.ssdc.caseprocessor.utils.HashHelper;
+import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
+
+@ContextConfiguration
+@ActiveProfiles("test")
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class EmailFulfilmentReceiverIT {
+
+  private static final String PACK_CODE = "TEST_EMAIL";
+  private static final Map<String, String> TEST_UAC_METADATA = Map.of("TEST_UAC_METADATA", "TEST");
+
+  @Value("${queueconfig.uac-update-topic}")
+  private String uacUpdateTopic;
+
+  @Autowired private PubsubHelper pubsubHelper;
+  @Autowired private DeleteDataHelper deleteDataHelper;
+  @Autowired private JunkDataHelper junkDataHelper;
+
+  @Autowired private UacQidLinkRepository uacQidLinkRepository;
+
+  @Autowired private UacQidServiceClient uacQidServiceClient;
+
+  @BeforeEach
+  public void setUp() {
+    pubsubHelper.purgeSharedProjectMessages(OUTBOUND_UAC_SUBSCRIPTION, uacUpdateTopic);
+    deleteDataHelper.deleteAllData();
+  }
+
+  @Test
+  void testEmailFulfilment() throws Exception {
+    // Given
+    // Get a new UAC QID pair
+    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1, 1);
+    UacQidDTO emailUacQid = uacQidDTOList.get(0);
+
+    // Create the case
+    Case testCase = junkDataHelper.setupJunkCase();
+
+    // Build the event message
+    EnrichedEmailFulfilment enrichedEmailFulfilment = new EnrichedEmailFulfilment();
+    enrichedEmailFulfilment.setUac(emailUacQid.getUac());
+    enrichedEmailFulfilment.setQid(emailUacQid.getQid());
+    enrichedEmailFulfilment.setCaseId(testCase.getId());
+    enrichedEmailFulfilment.setPackCode(PACK_CODE);
+    enrichedEmailFulfilment.setUacMetadata(TEST_UAC_METADATA);
+
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setEnrichedEmailFulfilment(enrichedEmailFulfilment);
+
+    EventHeaderDTO eventHeader = new EventHeaderDTO();
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    eventHeader.setTopic(EMAIL_FULFILMENT_TOPIC);
+    junkDataHelper.junkify(eventHeader);
+
+    EventDTO event = new EventDTO();
+    event.setHeader(eventHeader);
+    event.setPayload(payloadDTO);
+
+    try (QueueSpy<EventDTO> outboundUacQueueSpy =
+        pubsubHelper.sharedProjectListen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
+      pubsubHelper.sendMessage(EMAIL_FULFILMENT_TOPIC, event);
+      EventDTO emittedEvent = outboundUacQueueSpy.checkExpectedMessageReceived();
+
+      assertThat(emittedEvent.getHeader().getTopic()).isEqualTo(uacUpdateTopic);
+
+      UacUpdateDTO uacUpdatedEvent = emittedEvent.getPayload().getUacUpdate();
+      assertThat(uacUpdatedEvent.getCaseId()).isEqualTo(testCase.getId());
+      assertThat(uacUpdatedEvent.getUacHash()).isEqualTo(HashHelper.hash(emailUacQid.getUac()));
+      assertThat(uacUpdatedEvent.getQid()).isEqualTo(emailUacQid.getQid());
+    }
+
+    List<UacQidLink> uacQidLinks = uacQidLinkRepository.findAll();
+    assertThat(uacQidLinks.size()).isEqualTo(1);
+    assertThat(uacQidLinks.get(0).getCaze().getId()).isEqualTo(testCase.getId());
+    assertThat(uacQidLinks.get(0).getMetadata()).isEqualTo(TEST_UAC_METADATA);
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
@@ -1,0 +1,188 @@
+package uk.gov.ons.ssdc.caseprocessor.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.MessageConstructor.constructMessage;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
+
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EnrichedEmailFulfilment;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.ssdc.caseprocessor.service.CaseService;
+import uk.gov.ons.ssdc.caseprocessor.service.UacService;
+import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.EventType;
+import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
+
+@ExtendWith(MockitoExtension.class)
+class EmailFulfilmentReceiverTest {
+
+  @InjectMocks EmailFulfilmentReceiver underTest;
+
+  @Mock CaseService caseService;
+  @Mock UacService uacService;
+  @Mock EventLogger eventLogger;
+
+  private static final UUID CASE_ID = UUID.randomUUID();
+  private static final String TEST_QID = "TEST_QID";
+  private static final String TEST_UAC = "TEST_UAC";
+  private static final String PACK_CODE = "TEST_EMAIL";
+  private static final Map<String, String> TEST_UAC_METADATA = Map.of("TEST_UAC_METADATA", "TEST");
+
+  private static final String EMAIL_FULFILMENT_DESCRIPTION = "Email fulfilment request received";
+
+  @Test
+  void testReceiveMessageHappyPathWithUacQid() {
+    // Given
+    Case testCase = new Case();
+    testCase.setId(CASE_ID);
+    EventDTO event = buildEnrichedEmailFulfilmentEventWithUacQid();
+    Message<byte[]> eventMessage = constructMessage(event);
+
+    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(uacService.existsByQid(TEST_QID)).thenReturn(false);
+
+    // When
+    underTest.receiveMessage(eventMessage);
+
+    // Then
+    verify(uacService)
+        .createLinkAndEmitNewUacQid(
+            testCase,
+            TEST_UAC,
+            TEST_QID,
+            TEST_UAC_METADATA,
+            TEST_CORRELATION_ID,
+            TEST_ORIGINATING_USER);
+    verify(eventLogger)
+        .logCaseEvent(
+            testCase,
+            EMAIL_FULFILMENT_DESCRIPTION,
+            EventType.EMAIL_FULFILMENT,
+            event,
+            eventMessage);
+  }
+
+  @Test
+  void testReceiveMessageHappyPathNoUacQid() {
+    // Given
+    Case testCase = new Case();
+    testCase.setId(CASE_ID);
+    EventDTO event = buildEnrichedEmailFulfilmentEvent();
+    Message<byte[]> eventMessage = constructMessage(event);
+
+    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+
+    // When
+    underTest.receiveMessage(eventMessage);
+
+    // Then
+    verifyNoInteractions(uacService);
+    verify(eventLogger)
+        .logCaseEvent(
+            testCase,
+            EMAIL_FULFILMENT_DESCRIPTION,
+            EventType.EMAIL_FULFILMENT,
+            event,
+            eventMessage);
+  }
+
+  @Test
+  void testReceiveMessageQidAlreadyLinkedToCorrectCase() {
+    // Given
+    Case testCase = new Case();
+    testCase.setId(CASE_ID);
+    EventDTO event = buildEnrichedEmailFulfilmentEventWithUacQid();
+    Message<byte[]> eventMessage = constructMessage(event);
+
+    UacQidLink existingUacQidLink = new UacQidLink();
+    existingUacQidLink.setQid(TEST_QID);
+    existingUacQidLink.setCaze(testCase);
+
+    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+
+    when(uacService.existsByQid(TEST_QID)).thenReturn(true);
+    when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);
+
+    // When
+    underTest.receiveMessage(eventMessage);
+
+    // Then
+    verify(uacService, never()).saveAndEmitUacUpdateEvent(any(), any(UUID.class), anyString());
+    verifyNoInteractions(eventLogger);
+  }
+
+  @Test
+  void testReceiveMessageQidAlreadyLinkedToOtherCase() {
+    // Given
+    Case testCase = new Case();
+    testCase.setId(CASE_ID);
+
+    Case otherCase = new Case();
+    otherCase.setId(UUID.randomUUID());
+
+    EventDTO event = buildEnrichedEmailFulfilmentEventWithUacQid();
+    Message<byte[]> eventMessage = constructMessage(event);
+
+    UacQidLink existingUacQidLink = new UacQidLink();
+    existingUacQidLink.setQid(TEST_QID);
+    existingUacQidLink.setCaze(otherCase);
+
+    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+
+    when(uacService.existsByQid(TEST_QID)).thenReturn(true);
+    when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);
+
+    // When, then throws
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> underTest.receiveMessage(eventMessage));
+    assertThat(thrown.getMessage())
+        .isEqualTo("Email fulfilment QID TEST_QID is already linked to a different case");
+    verifyNoInteractions(eventLogger);
+  }
+
+  private EventDTO buildEnrichedEmailFulfilmentEventWithUacQid() {
+    EventDTO event = buildEnrichedEmailFulfilmentEvent();
+    event.getPayload().getEnrichedEmailFulfilment().setUac(TEST_UAC);
+    event.getPayload().getEnrichedEmailFulfilment().setQid(TEST_QID);
+    return event;
+  }
+
+  private EventDTO buildEnrichedEmailFulfilmentEvent() {
+    EnrichedEmailFulfilment enrichedEmailFulfilment = new EnrichedEmailFulfilment();
+    enrichedEmailFulfilment.setCaseId(CASE_ID);
+    enrichedEmailFulfilment.setPackCode(PACK_CODE);
+    enrichedEmailFulfilment.setUacMetadata(TEST_UAC_METADATA);
+
+    EventHeaderDTO eventHeader = new EventHeaderDTO();
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
+    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setEnrichedEmailFulfilment(enrichedEmailFulfilment);
+
+    EventDTO event = new EventDTO();
+    event.setHeader(eventHeader);
+    event.setPayload(payloadDTO);
+
+    return event;
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/model/repository/EmailTemplateRepository.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/model/repository/EmailTemplateRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ssdc.caseprocessor.model.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
+
+@Component
+@ActiveProfiles("test")
+public interface EmailTemplateRepository extends JpaRepository<EmailTemplate, String> {}

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/model/repository/SmsTemplateRepository.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/model/repository/SmsTemplateRepository.java
@@ -1,6 +1,10 @@
 package uk.gov.ons.ssdc.caseprocessor.model.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
 import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 
+@Component
+@ActiveProfiles("test")
 public interface SmsTemplateRepository extends JpaRepository<SmsTemplate, String> {}

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
@@ -168,7 +168,7 @@ class ActionRuleIT {
 
   @Test
   void testEmailRule() throws Exception {
-    try (QueueSpy<EventDTO> smsRequestQueue =
+    try (QueueSpy<EventDTO> emailRequestQueue =
         pubsubHelper.listen(OUTBOUND_EMAIL_REQUEST_SUBSCRIPTION, EventDTO.class)) {
       // Given
       Case caze = junkDataHelper.setupJunkCase();
@@ -178,7 +178,7 @@ class ActionRuleIT {
       // When
       setUpActionRule(
           ActionRuleType.EMAIL, caze.getCollectionExercise(), null, null, emailTemplate);
-      EventDTO rme = smsRequestQueue.getQueue().poll(20, TimeUnit.SECONDS);
+      EventDTO rme = emailRequestQueue.getQueue().poll(20, TimeUnit.SECONDS);
 
       // Then
       assertThat(rme).isNotNull();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.schedule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_EMAIL_REQUEST_SUBSCRIPTION;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_SMS_REQUEST_SUBSCRIPTION;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
 
@@ -21,6 +22,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ActionRuleRepository;
+import uk.gov.ons.ssdc.caseprocessor.model.repository.EmailTemplateRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.EventRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ExportFileRowRepository;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ExportFileTemplateRepository;
@@ -35,6 +37,7 @@ import uk.gov.ons.ssdc.common.model.entity.ActionRule;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleType;
 import uk.gov.ons.ssdc.common.model.entity.Case;
 import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
+import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Event;
 import uk.gov.ons.ssdc.common.model.entity.EventType;
 import uk.gov.ons.ssdc.common.model.entity.ExportFileRow;
@@ -58,6 +61,9 @@ class ActionRuleIT {
   @Value("${queueconfig.sms-request-topic}")
   private String smsRequestTopic;
 
+  @Value("${queueconfig.email-request-topic}")
+  private String emailRequestTopic;
+
   @Autowired private DeleteDataHelper deleteDataHelper;
   @Autowired private JunkDataHelper junkDataHelper;
 
@@ -67,6 +73,7 @@ class ActionRuleIT {
   @Autowired private ActionRuleRepository actionRuleRepository;
   @Autowired private ExportFileRowRepository exportFileRowRepository;
   @Autowired private SmsTemplateRepository smsTemplateRepository;
+  @Autowired private EmailTemplateRepository emailTemplateRepository;
   @Autowired private EventRepository eventRepository;
 
   @BeforeEach
@@ -85,7 +92,7 @@ class ActionRuleIT {
 
       // When
       setUpActionRule(
-          ActionRuleType.EXPORT_FILE, caze.getCollectionExercise(), exportFileTemplate, null);
+          ActionRuleType.EXPORT_FILE, caze.getCollectionExercise(), exportFileTemplate, null, null);
       EventDTO rme = outboundUacQueue.getQueue().poll(20, TimeUnit.SECONDS);
       List<ExportFileRow> exportFileRows = exportFileRowRepository.findAll();
       ExportFileRow exportFileRow = exportFileRows.get(0);
@@ -112,7 +119,8 @@ class ActionRuleIT {
       UacQidLink uacQidLink = setupUacQidLink(caze);
 
       // When
-      setUpActionRule(ActionRuleType.DEACTIVATE_UAC, caze.getCollectionExercise(), null, null);
+      setUpActionRule(
+          ActionRuleType.DEACTIVATE_UAC, caze.getCollectionExercise(), null, null, null);
       EventDTO rme = outboundUacQueue.getQueue().poll(20, TimeUnit.SECONDS);
 
       // Then
@@ -136,7 +144,7 @@ class ActionRuleIT {
       SmsTemplate smsTemplate = setupSmsTemplate();
 
       // When
-      setUpActionRule(ActionRuleType.SMS, caze.getCollectionExercise(), null, smsTemplate);
+      setUpActionRule(ActionRuleType.SMS, caze.getCollectionExercise(), null, smsTemplate, null);
       EventDTO rme = smsRequestQueue.getQueue().poll(20, TimeUnit.SECONDS);
 
       // Then
@@ -158,6 +166,39 @@ class ActionRuleIT {
     }
   }
 
+  @Test
+  void testEmailRule() throws Exception {
+    try (QueueSpy<EventDTO> smsRequestQueue =
+        pubsubHelper.listen(OUTBOUND_EMAIL_REQUEST_SUBSCRIPTION, EventDTO.class)) {
+      // Given
+      Case caze = junkDataHelper.setupJunkCase();
+
+      EmailTemplate emailTemplate = setupEmailTemplate();
+
+      // When
+      setUpActionRule(
+          ActionRuleType.EMAIL, caze.getCollectionExercise(), null, null, emailTemplate);
+      EventDTO rme = smsRequestQueue.getQueue().poll(20, TimeUnit.SECONDS);
+
+      // Then
+      assertThat(rme).isNotNull();
+      assertThat(rme.getHeader().getTopic()).isEqualTo(emailRequestTopic);
+      assertThat(rme.getPayload().getEmailRequest().getCaseId()).isEqualTo(caze.getId());
+      assertThat(rme.getPayload().getEmailRequest().getPackCode()).isEqualTo("Test pack code");
+      assertThat(rme.getPayload().getEmailRequest().getEmail()).isEqualTo("junk@junk.com");
+      assertThat(rme.getPayload().getEmailRequest().getUacMetadata()).isEqualTo(TEST_UAC_METADATA);
+
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isOne();
+      Event actualEvent = events.get(0);
+      assertThat(actualEvent.getType()).isEqualTo(EventType.ACTION_RULE_EMAIL_REQUEST);
+      PayloadDTO payloadDTO =
+          JsonHelper.convertJsonBytesToObject(
+              actualEvent.getPayload().getBytes(), PayloadDTO.class);
+      assertThat(payloadDTO.getEmailRequest().getEmail()).isEqualTo("REDACTED");
+    }
+  }
+
   private ExportFileTemplate setUpExportFileTemplate() {
     ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
     exportFileTemplate.setTemplate(new String[] {"__caseref__", "foo", "__uac__"});
@@ -171,7 +212,8 @@ class ActionRuleIT {
       ActionRuleType type,
       CollectionExercise collectionExercise,
       ExportFileTemplate exportFileTemplate,
-      SmsTemplate smsTemplate) {
+      SmsTemplate smsTemplate,
+      EmailTemplate emailTemplate) {
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
     actionRule.setTriggerDateTime(OffsetDateTime.now());
@@ -185,6 +227,11 @@ class ActionRuleIT {
     if (smsTemplate != null) {
       actionRule.setSmsTemplate(smsTemplate);
       actionRule.setPhoneNumberColumn("phoneNumber");
+    }
+
+    if (emailTemplate != null) {
+      actionRule.setEmailTemplate(emailTemplate);
+      actionRule.setEmailColumn("emailAddress");
     }
 
     return actionRuleRepository.saveAndFlush(actionRule);
@@ -207,5 +254,14 @@ class ActionRuleIT {
     smsTemplate.setTemplate(new String[] {"FOO", "BAR"});
     smsTemplate.setDescription("Test description");
     return smsTemplateRepository.saveAndFlush(smsTemplate);
+  }
+
+  private EmailTemplate setupEmailTemplate() {
+    EmailTemplate emailTemplate = new EmailTemplate();
+    emailTemplate.setPackCode("Test pack code");
+    emailTemplate.setNotifyTemplateId(UUID.randomUUID());
+    emailTemplate.setTemplate(new String[] {"FOO", "BAR"});
+    emailTemplate.setDescription("Test description");
+    return emailTemplateRepository.saveAndFlush(emailTemplate);
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/EmailProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/EmailProcessorTest.java
@@ -1,0 +1,75 @@
+package uk.gov.ons.ssdc.caseprocessor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
+import uk.gov.ons.ssdc.caseprocessor.messaging.MessageSender;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.ssdc.common.model.entity.ActionRule;
+import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
+import uk.gov.ons.ssdc.common.model.entity.EventType;
+
+@ExtendWith(MockitoExtension.class)
+class EmailProcessorTest {
+  @Mock private MessageSender messageSender;
+
+  @Mock private EventLogger eventLogger;
+
+  @InjectMocks private EmailProcessor underTest;
+
+  @Test
+  void testProcess() {
+    ReflectionTestUtils.setField(underTest, "emailRequestTopic", "Test topic");
+
+    Case caze = new Case();
+    caze.setId(UUID.randomUUID());
+    caze.setSampleSensitive(Map.of("superSecretEmailAddress", "secret@top.secret"));
+
+    EmailTemplate emailTemplate = new EmailTemplate();
+    emailTemplate.setPackCode("Test pack code");
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setCreatedBy("foo@bar.com");
+    actionRule.setEmailTemplate(emailTemplate);
+    actionRule.setEmailColumn("superSecretEmailAddress");
+
+    underTest.process(caze, actionRule);
+
+    ArgumentCaptor<EventDTO> eventArgCaptor = ArgumentCaptor.forClass(EventDTO.class);
+    verify(messageSender).sendMessage(eq("Test topic"), eventArgCaptor.capture());
+
+    EventDTO actualEvent = eventArgCaptor.getValue();
+    assertThat(actualEvent.getHeader().getTopic()).isEqualTo("Test topic");
+    assertThat(actualEvent.getHeader().getCorrelationId()).isEqualTo(actionRule.getId());
+    assertThat(actualEvent.getHeader().getOriginatingUser()).isEqualTo(actionRule.getCreatedBy());
+
+    assertThat(actualEvent.getPayload().getEmailRequest().getCaseId()).isEqualTo(caze.getId());
+    assertThat(actualEvent.getPayload().getEmailRequest().getPackCode())
+        .isEqualTo("Test pack code");
+    assertThat(actualEvent.getPayload().getEmailRequest().getEmail())
+        .isEqualTo("secret@top.secret");
+
+    verify(eventLogger)
+        .logCaseEvent(
+            eq(caze),
+            eq("Email requested by action rule for pack code Test pack code"),
+            eq(EventType.ACTION_RULE_EMAIL_REQUEST),
+            any(),
+            any(OffsetDateTime.class));
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/JunkDataHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/JunkDataHelper.java
@@ -34,7 +34,7 @@ public class JunkDataHelper {
     junkCase.setCollectionExercise(setupJunkCollex());
     junkCase.setCaseRef(RANDOM.nextLong());
     junkCase.setSample(Map.of("foo", "bar"));
-    junkCase.setSampleSensitive(Map.of("phoneNumber", "123"));
+    junkCase.setSampleSensitive(Map.of("phoneNumber", "123", "emailAddress", "junk@junk.com"));
     caseRepository.save(junkCase);
 
     return junkCase;

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConstants.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConstants.java
@@ -10,9 +10,12 @@ public class TestConstants {
   public static final String NEW_CASE_TOPIC = "event_new-case";
   public static final String OUTBOUND_SMS_REQUEST_SUBSCRIPTION =
       "rm-internal-sms-request-enriched_notify-service";
+  public static final String OUTBOUND_EMAIL_REQUEST_SUBSCRIPTION =
+      "rm-internal-email-request-enriched_notify-service";
 
   public static final String TELEPHONE_CAPTURE_TOPIC = "rm-internal-telephone-capture";
   public static final String SMS_FULFILMENT_TOPIC = "rm-internal-sms-fulfilment";
+  public static final String EMAIL_FULFILMENT_TOPIC = "rm-internal-email-fulfilment";
 
   public static final UUID TEST_CORRELATION_ID = UUID.randomUUID();
   public static final String TEST_ORIGINATING_USER = "foo@bar.com";

--- a/src/test/resources/setup_pubsub.sh
+++ b/src/test/resources/setup_pubsub.sh
@@ -12,6 +12,12 @@ curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-i
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-sms-fulfilment
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-sms-fulfilment_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-sms-fulfilment"}'
 
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-email-request
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-email-request-enriched_notify-service -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-email-request"}'
+
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-email-fulfilment
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-email-fulfilment_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-email-fulfilment"}'
+
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_new-case
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_new-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_new-case"}'
 


### PR DESCRIPTION
# Motivation and Context
We should be able to send emails, either in a batch (action rule) or individually ad-hoc (fulfilment).

# What has changed
Added EMAIL action rule type implementation, and also listen for internal messages requesting email fulfilment, and events coming from Notify Service, recording that a fulfilment has happened against a case.

# How to test?
Run the ATs. Try sending in some events on topic `rm-internal-email-fulfilment`. Check the integration with Notify Service by requesting some email fulfilments in the Support Tool.

# Links
Trello: https://trello.com/c/OPYjtKwf