### PR TITLE
Structured json logging

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.caseprocessor.config;
 
+import com.godaddy.logging.LoggingConfigs;
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import com.google.cloud.spring.pubsub.support.PublisherFactory;
 import com.google.cloud.spring.pubsub.support.SubscriberFactory;
@@ -43,6 +44,7 @@ public class AppConfig {
 
   @PostConstruct
   public void init() {
+    LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -44,6 +44,7 @@ public class AppConfig {
 
   @PostConstruct
   public void init() {
+//    This puts the actual log.with(object)  into the data part of the logging
     LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -44,7 +44,7 @@ public class AppConfig {
 
   @PostConstruct
   public void init() {
-//    This puts the actual log.with(object)  into the data part of the logging
+    //    This puts the actual log.with(object)  into the data part of the logging
     LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
   }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleScheduler.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleScheduler.java
@@ -4,6 +4,9 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.ReceiptDTO;
 
 @Service
 public class ActionRuleScheduler {
@@ -19,6 +22,20 @@ public class ActionRuleScheduler {
 
   @Scheduled(fixedDelayString = "${scheduler.frequency}")
   public void triggerActionRule() {
+//    This is a lazy hack to get instant logging without further effort
+    EventDTO event = new EventDTO();
+    PayloadDTO payloadDTO = new PayloadDTO();
+    ReceiptDTO receiptDTO = new ReceiptDTO();
+    receiptDTO.setQid("Testing, testing 123");
+    payloadDTO.setReceipt(receiptDTO);
+    event.setPayload(payloadDTO);
+
+    log.with(event).error("ERROR!!!");
+    log.with(event).warn("WARN!!!");
+    log.with(event).info("INFO!!!");
+    log.with(event).debug("DEBUGGING!!!");
+
+
     if (!clusterLeaderManager.isThisHostClusterLeader()) {
       return; // This host (i.e. pod) is not the leader... don't do any scheduling
     }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleScheduler.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleScheduler.java
@@ -22,7 +22,8 @@ public class ActionRuleScheduler {
 
   @Scheduled(fixedDelayString = "${scheduler.frequency}")
   public void triggerActionRule() {
-//    This is a lazy hack to get instant logging without further effort
+    //    This is a hack to get instant logging without needing to post etc
+    //    *** DO NOT MERGE ***
     EventDTO event = new EventDTO();
     PayloadDTO payloadDTO = new PayloadDTO();
     ReceiptDTO receiptDTO = new ReceiptDTO();
@@ -34,7 +35,6 @@ public class ActionRuleScheduler {
     log.with(event).warn("WARN!!!");
     log.with(event).info("INFO!!!");
     log.with(event).debug("DEBUGGING!!!");
-
 
     if (!clusterLeaderManager.isThisHostClusterLeader()) {
       return; // This host (i.e. pod) is not the leader... don't do any scheduling

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,7 +72,7 @@ messagelogging:
   logstacktraces: false
 
 logging:
-  profile: STRUCTURED
+  profile: DEV
   level:
     root: INFO
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,8 +70,9 @@ messagelogging:
   logstacktraces: false
 
 logging:
+  profile: STRUCTURED
   level:
-    org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler: ERROR
+    root: INFO
 
 caserefgeneratorkey: abc123
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -74,6 +74,16 @@
         </filter>
     </appender>
 
+    <appender class="ch.qos.logback.core.ConsoleAppender"
+              name="DEV">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+    </appender>
+
     <appender class="ch.qos.logback.classic.net.SyslogAppender"
               name="SYSLOG">
         <syslogHost>localhost</syslogHost>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+    <include
+            resource="org/springframework/boot/logging/logback/defaults.xml" />
+    <timestamp datePattern="yyyyMMdd'T'HHmmss" key="bySecond" />
+    <property resource="application.yml" />
+    <springProperty name="profile" source="logging.profile" />
+    <springProperty name="springAppName" scope="context"
+                    source="spring.application.name" />
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p})  %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+    <property name="SYSLOG_PATTERN"
+              value="${LOG_LEVEL_PATTERN:-%5level} %-40.40logger{39} : %message%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+    <property name="ISO8601_DATE_FORMAT"
+              value="yyyy-MM-dd'T'HH:mm:ss'Z'" />
+
+    <!-- Stop the unwanted logback INFO level logging at initialisation -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="STRUCTURED"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <encoder
+                class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <timeZone>UTC</timeZone>
+                    <pattern>${ISO8601_DATE_FORMAT}</pattern>
+                    <fieldName>created</fieldName>
+                </timestamp>
+                <globalCustomFields>
+                    <customFields>{"service":"Case Processor"}</customFields>
+                </globalCustomFields>
+                <message>
+                    <fieldName>event</fieldName>
+                </message>
+                <loggerName>
+                    <fieldName>context</fieldName>
+                </loggerName>
+                <threadName />
+                <logLevel>
+                    <fieldName>level</fieldName>
+                </logLevel>
+                <stackTrace>
+                    <throwableConverter
+                            class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                        <maxDepthPerThrowable>20</maxDepthPerThrowable>
+                        <maxLength>1000</maxLength>
+                        <shortenedClassNameLength>30</shortenedClassNameLength>
+                        <rootCauseFirst>true</rootCauseFirst>
+                    </throwableConverter>
+                </stackTrace>
+                <jsonMessage />
+                <mdc>
+                    <includeMdcKeyName>included</includeMdcKeyName>
+                </mdc>
+                <nestedField>
+                    <fieldName>data</fieldName>
+                    <providers>
+                        <arguments>
+                            <includeNonStructuredArguments>true
+                            </includeNonStructuredArguments>
+                            <nonStructuredArgumentsFieldPrefix>prefix
+                            </nonStructuredArgumentsFieldPrefix>
+                        </arguments>
+                        <tags />
+                        <logstashMarkers />
+                    </providers>
+                </nestedField>
+            </providers>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+    </appender>
+
+    <appender class="ch.qos.logback.classic.net.SyslogAppender"
+              name="SYSLOG">
+        <syslogHost>localhost</syslogHost>
+        <facility>DAEMON</facility>
+        <suffixPattern>${SYSLOG_PATTERN}</suffixPattern>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <root>
+        <appender-ref ref="${profile}" />
+        <appender-ref ref="SYSLOG" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
# Motivation and Context
Get nice structured logging, for severity, metrics, generally looking nice

# What has changed
Added a logback.xml file from old spike: https://github.com/ONSdigital/census-rm-case-processor/compare/spike-json-logging.
Made it so that the log level is set in the application.yml and easily overridden by our usual k8s gubbins.

There's a complete hack in the scheduled Action Rule task to display the logging easily by just deploying it.


# How to test?
Application.yml  now defaults to using the DEV (not structured) appender.  So locally you should see little or no difference
Change application.yml to use STRUCTURED, Build it, deploy it in GCP.  Play with the yml logging levels.  Do the logs appear in nice json

# Links
https://trello.com/c/D6g57xgB/2971-spike-structure-java-logging-so-that-it-gets-the-correct-gcp-severity-2-days
