### PR TITLE
add a second docker login into travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 before_install:
   - mvn fmt:check
   - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";
   - docker network create ssdcrmdockerdev_default
   - echo "$DOCKER_GCP_PASSWORD" > ~/google-service-account-key.json
   - export GOOGLE_APPLICATION_CREDENTIALS=~/google-service-account-key.json


### PR DESCRIPTION
# Motivation and Context
our travis builds are failing often due to dockerhub rate limiting failures, to solve this we need to log into an dockerhub enterprise account

# What has changed
- added a second docker login command line into .travis to use a enterprise dockerhub account

# How to test?
- trigger tests in travis and make sure it doesn't fail

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
