### PR TITLE
Migrate to shared events version 0.5.0 release

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/UacUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/UacUpdateDTO.java
@@ -12,6 +12,8 @@ public class UacUpdateDTO {
   private boolean active;
   private String qid;
   private UUID caseId;
+  private UUID collectionExerciseId;
+  private UUID surveyId;
   private boolean receiptReceived;
   private boolean eqLaunched;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/UacService.java
@@ -47,10 +47,9 @@ public class UacService {
     uac.setReceiptReceived(savedUacQidLink.isReceiptReceived());
     uac.setEqLaunched(savedUacQidLink.isEqLaunched());
 
-    Case caze = savedUacQidLink.getCaze();
-    if (caze != null) {
-      uac.setCaseId(caze.getId());
-    }
+    uac.setCaseId(savedUacQidLink.getCaze().getId());
+    uac.setCollectionExerciseId(savedUacQidLink.getCaze().getCollectionExercise().getId());
+    uac.setSurveyId(savedUacQidLink.getCaze().getCollectionExercise().getSurvey().getId());
 
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setUacUpdate(uac);

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
@@ -3,7 +3,7 @@ package uk.gov.ons.ssdc.caseprocessor.utils;
 import java.util.Set;
 
 public class Constants {
-  public static final String OUTBOUND_EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
+  public static final String OUTBOUND_EVENT_SCHEMA_VERSION = "0.5.0";
   public static final Set<String> ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS =
-      Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0");
+      Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0", "0.5.0-DRAFT", "0.5.0", "0.6.0-DRAFT");
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/UacServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/UacServiceTest.java
@@ -25,6 +25,8 @@ import uk.gov.ons.ssdc.caseprocessor.model.dto.UacUpdateDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.UacQidLinkRepository;
 import uk.gov.ons.ssdc.caseprocessor.utils.HashHelper;
 import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,11 +44,23 @@ public class UacServiceTest {
     ReflectionTestUtils.setField(underTest, "uacUpdateTopic", "Test topic");
     ReflectionTestUtils.setField(underTest, "sharedPubsubProject", "Test project");
 
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(UUID.randomUUID());
+    collectionExercise.setSurvey(survey);
+
+    Case caze = new Case();
+    caze.setId(UUID.randomUUID());
+    caze.setCollectionExercise(collectionExercise);
+
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setUac("abc");
     uacQidLink.setQid("01234");
     uacQidLink.setActive(true);
+    uacQidLink.setCaze(caze);
 
     when(uacQidLinkRepository.save(uacQidLink)).thenReturn(uacQidLink);
     underTest.saveAndEmitUacUpdateEvent(uacQidLink, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
@@ -64,6 +78,9 @@ public class UacServiceTest {
     UacUpdateDTO uacUpdateDto = actualEvent.getPayload().getUacUpdate();
     assertThat(uacUpdateDto.getUacHash()).isEqualTo(TEST_UAC_HASH);
     assertThat(uacUpdateDto.getQid()).isEqualTo(uacUpdateDto.getQid());
+    assertThat(uacUpdateDto.getCaseId()).isEqualTo(caze.getId());
+    assertThat(uacUpdateDto.getSurveyId()).isEqualTo(survey.getId());
+    assertThat(uacUpdateDto.getCollectionExerciseId()).isEqualTo(collectionExercise.getId());
   }
 
   @Test
@@ -106,8 +123,16 @@ public class UacServiceTest {
     String qid = "TEST_QID";
     String uac = "TEST_UAC";
 
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(UUID.randomUUID());
+    collectionExercise.setSurvey(survey);
+
     Case testCase = new Case();
     testCase.setId(UUID.randomUUID());
+    testCase.setCollectionExercise(collectionExercise);
     UacQidLink expectedSavedUacQidLink = new UacQidLink();
     expectedSavedUacQidLink.setUac(uac);
     expectedSavedUacQidLink.setQid(qid);


### PR DESCRIPTION
# Motivation and Context
We have released `0.5.0` of the [shared events](https://github.com/ONSdigital/ssdc-shared-events) so it's time to bring our microservices in line with that spec.

# What has changed
Changed all the microservices to publish `0.5.0` as the event version in the headers, and do a few other tweaks to meet the specification.

Also, allow some more versions to be sent to us for present and future needs.

# How to test?
Zero regression - ATs should pass.

# Links
Trello: https://trello.com/c/9uTTLrLW