### PR TITLE
Fix simultaneous sample updates overwriting each other

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiver.java
@@ -37,7 +37,7 @@ public class EmailFulfilmentReceiver {
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
     EnrichedEmailFulfilment emailFulfilment = event.getPayload().getEnrichedEmailFulfilment();
 
-    Case caze = caseService.getCaseByCaseId(emailFulfilment.getCaseId());
+    Case caze = caseService.getCase(emailFulfilment.getCaseId());
 
     if (emailFulfilment.getQid() != null) {
       // Check the QID does not already exist

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiver.java
@@ -27,7 +27,7 @@ public class InvalidCaseReceiver {
   public void receiveMessage(Message<byte[]> message) {
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
 
-    Case caze = caseService.getCaseByCaseId(event.getPayload().getInvalidCase().getCaseId());
+    Case caze = caseService.getCase(event.getPayload().getInvalidCase().getCaseId());
 
     caze.setInvalid(true);
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiver.java
@@ -37,7 +37,7 @@ public class PrintFulfilmentReceiver {
   public void receiveMessage(Message<byte[]> message) {
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
 
-    Case caze = caseService.getCaseByCaseId(event.getPayload().getPrintFulfilment().getCaseId());
+    Case caze = caseService.getCase(event.getPayload().getPrintFulfilment().getCaseId());
 
     ExportFileTemplate exportFileTemplate =
         getAllowedPrintTemplate(event.getPayload().getPrintFulfilment().getPackCode(), caze);

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
@@ -30,7 +30,7 @@ public class RefusalReceiver {
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
 
     RefusalDTO refusal = event.getPayload().getRefusal();
-    Case refusedCase = caseService.getCaseByCaseId(refusal.getCaseId());
+    Case refusedCase = caseService.getCase(refusal.getCaseId());
     refusedCase.setRefusalReceived(RefusalType.valueOf(refusal.getType().name()));
 
     caseService.saveCaseAndEmitCaseUpdate(

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiver.java
@@ -37,7 +37,7 @@ public class SmsFulfilmentReceiver {
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
     EnrichedSmsFulfilment smsFulfilment = event.getPayload().getEnrichedSmsFulfilment();
 
-    Case caze = caseService.getCaseByCaseId(smsFulfilment.getCaseId());
+    Case caze = caseService.getCase(smsFulfilment.getCaseId());
 
     if (smsFulfilment.getQid() != null) {
       // Check the QID does not already exist

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiver.java
@@ -37,7 +37,7 @@ public class TelephoneCaptureReceiver {
 
     TelephoneCaptureDTO telephoneCapturePayload = event.getPayload().getTelephoneCapture();
 
-    Case caze = caseService.getCaseByCaseId(telephoneCapturePayload.getCaseId());
+    Case caze = caseService.getCase(telephoneCapturePayload.getCaseId());
 
     // Double check the QID does not already exist
     if (uacService.existsByQid(telephoneCapturePayload.getQid())) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiver.java
@@ -7,6 +7,7 @@ import java.util.Map.Entry;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
@@ -28,14 +29,14 @@ public class UpdateSampleReceiver {
     this.eventLogger = eventLogger;
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.REPEATABLE_READ)
   @ServiceActivator(inputChannel = "updateSampleInputChannel", adviceChain = "retryAdvice")
   public void receiveMessage(Message<byte[]> message) {
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
 
     UpdateSample updateSample = event.getPayload().getUpdateSample();
 
-    Case caze = caseService.getCaseByCaseId(updateSample.getCaseId());
+    Case caze = caseService.getCaseAndLockForUpdate(updateSample.getCaseId());
 
     for (Map.Entry<String, String> entry : updateSample.getSample().entrySet()) {
       // Validate that only existing sample data is being attempted to be updated

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/repository/CaseRepository.java
@@ -1,7 +1,15 @@
 package uk.gov.ons.ssdc.caseprocessor.model.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uk.gov.ons.ssdc.common.model.entity.Case;
 
-public interface CaseRepository extends JpaRepository<Case, UUID> {}
+public interface CaseRepository extends JpaRepository<Case, UUID> {
+  @Query(
+      value = "SELECT * FROM casev3.cases WHERE id = :id FOR UPDATE SKIP LOCKED",
+      nativeQuery = true)
+  Optional<Case> findByIdWithUpdateLock(@Param("id") UUID id);
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -79,12 +79,24 @@ public class CaseService {
     return event;
   }
 
-  public Case getCaseByCaseId(UUID caseId) {
+  public Case getCase(UUID caseId) {
     Optional<Case> cazeResult = caseRepository.findById(caseId);
 
     if (cazeResult.isEmpty()) {
-      throw new RuntimeException(String.format("Case ID '%s' not present", caseId));
+      throw new RuntimeException(String.format("Case with ID '%s' not found", caseId));
     }
+    return cazeResult.get();
+  }
+
+  public Case getCaseAndLockForUpdate(UUID caseId) {
+    Optional<Case> cazeResult = caseRepository.findByIdWithUpdateLock(caseId);
+
+    if (cazeResult.isEmpty()) {
+      throw new RuntimeException(
+          String.format(
+              "Case with ID '%s' not found, or could not obtain lock due to contention", caseId));
+    }
+
     return cazeResult.get();
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
@@ -57,7 +57,7 @@ class EmailFulfilmentReceiverTest {
     EventDTO event = buildEnrichedEmailFulfilmentEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
     when(uacService.existsByQid(TEST_QID)).thenReturn(false);
 
     // When
@@ -89,7 +89,7 @@ class EmailFulfilmentReceiverTest {
     EventDTO event = buildEnrichedEmailFulfilmentEvent();
     Message<byte[]> eventMessage = constructMessage(event);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     // When
     underTest.receiveMessage(eventMessage);
@@ -117,7 +117,7 @@ class EmailFulfilmentReceiverTest {
     existingUacQidLink.setQid(TEST_QID);
     existingUacQidLink.setCaze(testCase);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     when(uacService.existsByQid(TEST_QID)).thenReturn(true);
     when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);
@@ -146,7 +146,7 @@ class EmailFulfilmentReceiverTest {
     existingUacQidLink.setQid(TEST_QID);
     existingUacQidLink.setCaze(otherCase);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     when(uacService.existsByQid(TEST_QID)).thenReturn(true);
     when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/InvalidCaseReceiverTest.java
@@ -55,7 +55,7 @@ public class InvalidCaseReceiverTest {
     // Given
     Case expectedCase = new Case();
     expectedCase.setInvalid(false);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCase(any(UUID.class))).thenReturn(expectedCase);
 
     // when
     underTest.receiveMessage(message);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiverTest.java
@@ -77,7 +77,7 @@ class PrintFulfilmentReceiverTest {
         .getCollectionExercise()
         .getSurvey()
         .setFulfilmentExportFileTemplates(List.of(fulfilmentSurveyExportFileTemplate));
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCase(any(UUID.class))).thenReturn(expectedCase);
 
     // When
     underTest.receiveMessage(message);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
@@ -66,7 +66,7 @@ public class RefusalReceiverTest {
     caze.setId(CASE_ID);
     caze.setRefusalReceived(null);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(caze);
+    when(caseService.getCase(CASE_ID)).thenReturn(caze);
 
     // When
     underTest.receiveMessage(message);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
@@ -57,7 +57,7 @@ class SmsFulfilmentReceiverTest {
     EventDTO event = buildEnrichedSmsFulfilmentEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
     when(uacService.existsByQid(TEST_QID)).thenReturn(false);
 
     // When
@@ -85,7 +85,7 @@ class SmsFulfilmentReceiverTest {
     EventDTO event = buildEnrichedSmsFulfilmentEvent();
     Message<byte[]> eventMessage = constructMessage(event);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     // When
     underTest.receiveMessage(eventMessage);
@@ -109,7 +109,7 @@ class SmsFulfilmentReceiverTest {
     existingUacQidLink.setQid(TEST_QID);
     existingUacQidLink.setCaze(testCase);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     when(uacService.existsByQid(TEST_QID)).thenReturn(true);
     when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);
@@ -138,7 +138,7 @@ class SmsFulfilmentReceiverTest {
     existingUacQidLink.setQid(TEST_QID);
     existingUacQidLink.setCaze(otherCase);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     when(uacService.existsByQid(TEST_QID)).thenReturn(true);
     when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/TelephoneCaptureReceiverTest.java
@@ -50,7 +50,7 @@ class TelephoneCaptureReceiverTest {
     EventDTO event = buildTelephoneCaptureEvent();
     Message<byte[]> eventMessage = constructMessage(event);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
     when(uacService.existsByQid(TEST_QID)).thenReturn(false);
 
     // When
@@ -82,7 +82,7 @@ class TelephoneCaptureReceiverTest {
     existingUacQidLink.setQid(TEST_QID);
     existingUacQidLink.setCaze(testCase);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     when(uacService.existsByQid(TEST_QID)).thenReturn(true);
     when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);
@@ -111,7 +111,7 @@ class TelephoneCaptureReceiverTest {
     existingUacQidLink.setQid(TEST_QID);
     existingUacQidLink.setCaze(otherCase);
 
-    when(caseService.getCaseByCaseId(CASE_ID)).thenReturn(testCase);
+    when(caseService.getCase(CASE_ID)).thenReturn(testCase);
 
     when(uacService.existsByQid(TEST_QID)).thenReturn(true);
     when(uacService.findByQid(TEST_QID)).thenReturn(existingUacQidLink);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverTest.java
@@ -80,7 +80,7 @@ public class UpdateSampleReceiverTest {
     expectedCase.setSample(sampleData);
     expectedCase.setSampleSensitive(new HashMap<>());
 
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // when
     underTest.receiveMessage(message);
@@ -118,7 +118,7 @@ public class UpdateSampleReceiverTest {
     Map<String, String> existingSampleData = new HashMap<>();
     existingSampleData.put("testThing", "xyz666");
     expectedCase.setSample(existingSampleData);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // When, then throws
     RuntimeException thrown =
@@ -152,7 +152,7 @@ public class UpdateSampleReceiverTest {
     Map<String, String> existingSensitiveSampleData = new HashMap<>();
     existingSensitiveSampleData.put("mobileNumber", "111111111");
     expectedCase.setSampleSensitive(existingSensitiveSampleData);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // When, then throws
     RuntimeException thrown =
@@ -194,7 +194,7 @@ public class UpdateSampleReceiverTest {
     Map<String, String> existingSampleData = new HashMap<>();
     existingSampleData.put("testSampleField", "Test");
     expectedCase.setSample(existingSampleData);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // When, then throws
     RuntimeException thrown =

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiverTest.java
@@ -81,7 +81,7 @@ class UpdateSampleSensitiveReceiverTest {
     Map<String, String> sensitiveData = new HashMap<>();
     sensitiveData.put("PHONE_NUMBER", "1111111");
     expectedCase.setSampleSensitive(sensitiveData);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // when
     underTest.receiveMessage(message);
@@ -139,7 +139,7 @@ class UpdateSampleSensitiveReceiverTest {
     Map<String, String> sensitiveData = new HashMap<>();
     sensitiveData.put("PHONE_NUMBER", "1111111");
     expectedCase.setSampleSensitive(sensitiveData);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // when
     underTest.receiveMessage(message);
@@ -184,7 +184,7 @@ class UpdateSampleSensitiveReceiverTest {
     Map<String, String> sensitiveData = new HashMap<>();
     sensitiveData.put("PHONE_NUMBER", "1111111");
     expectedCase.setSampleSensitive(sensitiveData);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // When, then throws
     assertThrows(RuntimeException.class, () -> underTest.receiveMessage(message));
@@ -226,7 +226,7 @@ class UpdateSampleSensitiveReceiverTest {
     Map<String, String> sensitiveData = new HashMap<>();
     sensitiveData.put("PHONE_NUMBER", "123");
     expectedCase.setSampleSensitive(sensitiveData);
-    when(caseService.getCaseByCaseId(any(UUID.class))).thenReturn(expectedCase);
+    when(caseService.getCaseAndLockForUpdate(any(UUID.class))).thenReturn(expectedCase);
 
     // When, then throws
     assertThrows(RuntimeException.class, () -> underTest.receiveMessage(message));

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
@@ -129,7 +129,7 @@ public class CaseServiceTest {
     Optional<Case> caseOpt = Optional.of(caze);
     when(caseRepository.findById(any())).thenReturn(caseOpt);
 
-    Case returnedCase = underTest.getCaseByCaseId(caze.getId());
+    Case returnedCase = underTest.getCase(caze.getId());
     assertThat(returnedCase).isEqualTo(caze);
     verify(caseRepository).findById(caze.getId());
   }
@@ -137,10 +137,9 @@ public class CaseServiceTest {
   @Test
   public void getByCaseIdMissingCase() {
     UUID caseId = UUID.randomUUID();
-    String expectedErrorMessage = String.format("Case ID '%s' not present", caseId);
+    String expectedErrorMessage = String.format("Case with ID '%s' not found", caseId);
 
-    RuntimeException thrown =
-        assertThrows(RuntimeException.class, () -> underTest.getCaseByCaseId(caseId));
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> underTest.getCase(caseId));
 
     assertThat(thrown.getMessage()).isEqualTo(expectedErrorMessage);
   }


### PR DESCRIPTION
# Motivation and Context
Attempting to simultaneously update more than one item of sample data, or sensitive sample data, can result in changes from one or the other of them being lost due to the overlapping attempts to write the same piece of JSON data.

Fundamentally, Postgres provides no functionality to only update a small part of a JSON binary blob column... the Postgres functions like `jsonb_set` are only convenience methods for manipulating JSON on Postgres, and do not change the fundamental thing that is happening: that the JSON is manipulated and then _replaced_ in its entirety, and as such, in the event that two SQL `UPDATE` statements are simultaneously executing, values will be overwritten by whatever was in memory at the time of update.

# What has changed
The only way to solve this "dead heat" problem is to lock the row for the duration of the update. Using 'repeatable read' transaction isolation gives further protection, preventing data corruption which occurs after a transaction has committed, but another transaction has a 'working copy' of the data in memory.

# How to test?
Use the bulk processor to update several fields of a single case at once, and you should see that all values are updated successfully... previously some of the updates would have been lost.

# Links
Trello: https://trello.com/c/vB3gAseM