### PR TITLE
Use improved PubSub [auto] nacking for ManagedMessageRecoverer class

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,7 @@ logging:
   profile: DEV
   level:
     root: INFO
+    com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter: ERROR
 
 caserefgeneratorkey: abc123
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ManagedMessageRecovererTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
@@ -22,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.retry.RetryContext;
@@ -41,13 +43,14 @@ class ManagedMessageRecovererTest {
   @InjectMocks private ManagedMessageRecoverer underTest;
 
   @Test
-  public void testRecover() throws Exception {
+  public void testRecover() {
     // Given
     ExceptionReportResponse exceptionReportResponse = new ExceptionReportResponse();
     RetryContext retryContext = testSetupTestRecover(exceptionReportResponse);
 
     // When
-    underTest.recover(retryContext);
+    MessageHandlingException thrownException =
+        assertThrows(MessageHandlingException.class, () -> underTest.recover(retryContext));
 
     // Then
     verify(exceptionManagerClient)
@@ -57,19 +60,22 @@ class ManagedMessageRecovererTest {
             eq("TEST SUBSCRIPTION"),
             any(Throwable.class),
             anyString());
-    verify(originalMessage).nack();
+    verify(originalMessage, never()).nack();
     verify(originalMessage, never()).ack();
+    assertThat(thrownException.getMessage())
+        .isEqualTo("Cannot process this message at this time, but it will be retried");
   }
 
   @Test
-  public void testRecoverLogIt() throws Exception {
+  public void testRecoverLogIt() {
     // Given
     ExceptionReportResponse exceptionReportResponse = new ExceptionReportResponse();
     exceptionReportResponse.setLogIt(true);
     RetryContext retryContext = testSetupTestRecover(exceptionReportResponse);
 
     // When
-    underTest.recover(retryContext);
+    MessageHandlingException thrownException =
+        assertThrows(MessageHandlingException.class, () -> underTest.recover(retryContext));
 
     // Then
     verify(exceptionManagerClient)
@@ -80,12 +86,14 @@ class ManagedMessageRecovererTest {
             any(RuntimeException.class),
             contains(
                 "uk.gov.ons.ssdc.caseprocessor.messaging.ManagedMessageRecovererTest.testSetupTestRecover"));
-    verify(originalMessage).nack();
+    verify(originalMessage, never()).nack();
     verify(originalMessage, never()).ack();
+    assertThat(thrownException.getMessage())
+        .isEqualTo("Cannot process this message at this time, but it will be retried");
   }
 
   @Test
-  public void testRecoverSkip() throws Exception {
+  public void testRecoverSkip() {
     // Given
     ExceptionReportResponse exceptionReportResponse = new ExceptionReportResponse();
     exceptionReportResponse.setSkipIt(true);
@@ -104,7 +112,7 @@ class ManagedMessageRecovererTest {
             contains(
                 "uk.gov.ons.ssdc.caseprocessor.messaging.ManagedMessageRecovererTest.testSetupTestRecover"));
     verify(originalMessage, never()).nack();
-    verify(originalMessage, never()).ack(); // No exception thrown = recover ack
+    verify(originalMessage, never()).ack();
 
     ArgumentCaptor<SkippedMessage> skippedMessageArgCapt =
         ArgumentCaptor.forClass(SkippedMessage.class);
@@ -117,7 +125,7 @@ class ManagedMessageRecovererTest {
   }
 
   @Test
-  public void testRecoverSkipFailureDoesNotAck() throws Exception {
+  public void testRecoverSkipFailureDoesNotAck() {
     // Given
     ExceptionReportResponse exceptionReportResponse = new ExceptionReportResponse();
     exceptionReportResponse.setSkipIt(true);
@@ -128,7 +136,8 @@ class ManagedMessageRecovererTest {
         .storeMessageBeforeSkipping(any(SkippedMessage.class));
 
     // When
-    underTest.recover(retryContext);
+    MessageHandlingException thrownException =
+        assertThrows(MessageHandlingException.class, () -> underTest.recover(retryContext));
 
     // Then
     verify(exceptionManagerClient)
@@ -139,19 +148,22 @@ class ManagedMessageRecovererTest {
             any(RuntimeException.class),
             contains(
                 "uk.gov.ons.ssdc.caseprocessor.messaging.ManagedMessageRecovererTest.testSetupTestRecover"));
-    verify(originalMessage).nack();
+    verify(originalMessage, never()).nack();
     verify(originalMessage, never()).ack();
+    assertThat(thrownException.getMessage())
+        .isEqualTo("Cannot process this message at this time, but it will be retried");
   }
 
   @Test
-  public void testRecoverPeek() throws Exception {
+  public void testRecoverPeek() {
     // Given
     ExceptionReportResponse exceptionReportResponse = new ExceptionReportResponse();
     exceptionReportResponse.setPeek(true);
     RetryContext retryContext = testSetupTestRecover(exceptionReportResponse);
 
     // When
-    underTest.recover(retryContext);
+    MessageHandlingException thrownException =
+        assertThrows(MessageHandlingException.class, () -> underTest.recover(retryContext));
 
     // Then
     verify(exceptionManagerClient)
@@ -162,8 +174,10 @@ class ManagedMessageRecovererTest {
             any(RuntimeException.class),
             contains(
                 "uk.gov.ons.ssdc.caseprocessor.messaging.ManagedMessageRecovererTest.testSetupTestRecover"));
-    verify(originalMessage).nack();
+    verify(originalMessage, never()).nack();
     verify(originalMessage, never()).ack();
+    assertThat(thrownException.getMessage())
+        .isEqualTo("Cannot process this message at this time, but it will be retried");
 
     verify(exceptionManagerClient).respondToPeek(TEST_MESSAGE_HASH, "TEST PAYLOAD".getBytes());
   }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/ManagedMessageRecovererTest.java
@@ -33,7 +33,7 @@ import uk.gov.ons.ssdc.caseprocessor.model.dto.SkippedMessage;
 
 @ExtendWith(MockitoExtension.class)
 class ManagedMessageRecovererTest {
-  private static String TEST_MESSAGE_HASH =
+  private static final String TEST_MESSAGE_HASH =
       "90f56b5b3ffe9558a546af25a7256da4b2761864575f9d59c81b70629023465b";
 
   @Mock private BasicAcknowledgeablePubsubMessage originalMessage;


### PR DESCRIPTION
# Motivation and Context
The Spring Google Pub/Sub libraries don't offer any obvious way to handle errors... it's fairly undocumented. Previously, we were manually nack'ing Pub/Sub messages that we wanted to be retried. On reflection, it would be better if Spring nack'ed the messages, because there's a concern that we might be nack'ing a message which Spring goes on to ack, creating a race condition between what we've done, and what Spring is trying to do.

# What has changed
Instead of nack'ing the message ourselves, we throw an exception, so that Spring nacks the message. However, this would cause unwanted logging, so we've changed the logging level to suppress the warnings about auto-nacking.

# How to test?
Send in some bad messages and make sure that they don't get lost.

# Links
Trello: https://trello.com/c/0WllcvES