### PR TITLE
Java 17 and spring boot 2 6 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 
 language: java
-jdk: openjdk11
+jdk: openjdk17
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:17-jdk-slim
 
 ARG JAR_FILE=ssdc-rm-caseprocessor*.jar
 
-CMD ["/usr/local/openjdk-11/bin/java", "-jar", "/opt/ssdc-rm-caseprocessor.jar"]
+CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-caseprocessor.jar"]
 COPY healthcheck.sh /opt/healthcheck.sh
 RUN chmod +x /opt/healthcheck.sh
 RUN groupadd --gid 999 caseprocessor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM openjdk:17-jdk-slim
 
 ARG JAR_FILE=ssdc-rm-caseprocessor*.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,13 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.2</version>
+    <version>2.6.0</version>
   </parent>
 
   <dependencyManagement>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.6</version>
+      <version>1.18.20</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -235,7 +235,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
+        <version>0.8.7</version>
         <executions>
           <execution>
             <goals>
@@ -254,8 +254,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.11</source>
-          <target>1.11</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,12 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.9.0-SNAPSHOT</version>
+      <version>4.10.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Motivation and Context
Java 11 is no longer the LTS (Long-Term Support) version. Java 17 is the LTS version, so we should use that.

Spring Boot 2.6.0 is the first version of Spring Boot to support Java 17, so we should use that too.

# What has changed
Upgraded to Java 17 and Spring Boot 2.6.0, plus upped any other versions required for everything to work.

Switched the Docker base image over to be JDK 17 too.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/kcJGECdH