### PR TITLE
use new validateRowWithDataExcludedErrorMsgs and throw exception with more info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.3.0-SNAPSHOT</version>
+      <version>1.4.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiver.java
@@ -97,16 +97,17 @@ public class NewCaseReceiver {
       Optional<String> columnValidationErrors;
 
       if (columnValidator.isSensitive()) {
-        columnValidationErrors = columnValidator.validateRow(newCasePayload.getSampleSensitive());
+        columnValidationErrors =
+            columnValidator.validateRowWithDataExcludedErrorMsgs(
+                newCasePayload.getSampleSensitive());
       } else {
-        columnValidationErrors = columnValidator.validateRow(newCasePayload.getSample());
+        columnValidationErrors =
+            columnValidator.validateRowWithDataExcludedErrorMsgs(newCasePayload.getSample());
       }
 
       if (columnValidationErrors.isPresent()) {
         throw new RuntimeException(
-            String.format(
-                "New case event failed validation on column \"%s\"",
-                columnValidator.getColumnName()));
+            "NEW_CASE event: " + columnValidationErrors.get());
       }
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/SampleValidateHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/SampleValidateHelper.java
@@ -13,10 +13,10 @@ public class SampleValidateHelper {
     if (columnValidator.getColumnName().equals(entry.getKey())) {
       Map<String, String> validateThis = Map.of(entry.getKey(), entry.getValue());
 
-      Optional<String> validationErrors = columnValidator.validateRow(validateThis);
+      Optional<String> validationErrors =
+          columnValidator.validateRowWithDataExcludedErrorMsgs(validateThis);
       if (validationErrors.isPresent()) {
-        throw new RuntimeException(
-            eventType + " failed validation for column name: " + columnValidator.getColumnName());
+        throw new RuntimeException(eventType + " event: " + validationErrors.get());
       }
     }
   }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiverTest.java
@@ -249,7 +249,8 @@ public class NewCaseReceiverTest {
     RuntimeException thrownException =
         assertThrows(RuntimeException.class, () -> underTest.receiveNewCase(eventMessage));
     assertThat(thrownException.getMessage())
-        .isEqualTo("New case event failed validation on column \"POSTCODE\"");
+        .isEqualTo(
+            "NEW_CASE event: Column 'POSTCODE' Failed validation for Rule 'LengthRule' validation error: Exceeded max length of 8");
     verifyNoInteractions(eventLogger);
   }
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverTest.java
@@ -200,7 +200,8 @@ public class UpdateSampleReceiverTest {
     RuntimeException thrown =
         assertThrows(RuntimeException.class, () -> underTest.receiveMessage(message));
     assertThat(thrown.getMessage())
-        .isEqualTo("UPDATE_SAMPLE failed validation for column name: testSampleField");
+        .isEqualTo(
+            "UPDATE_SAMPLE event: Column 'testSampleField' Failed validation for Rule 'LengthRule' validation error: Exceeded max length of 4");
 
     verify(caseService, never()).saveCase(any());
     verify(eventLogger, never()).logCaseEvent(any(), any(), any(), any(), any(Message.class));

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/SampleValidateHelperTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/utils/SampleValidateHelperTest.java
@@ -45,6 +45,7 @@ class SampleValidateHelperTest {
 
     // Then
     assertThat(thrown.getMessage())
-        .isEqualTo("UPDATE_SAMPLE_SENSITIVE failed validation for column name: testSampleField");
+        .isEqualTo(
+            "UPDATE_SAMPLE_SENSITIVE event: Column 'testSampleField' Failed validation for Rule 'LengthRule' validation error: Exceeded max length of 1");
   }
 }


### PR DESCRIPTION
# Motivation and Context
Log more info, without the data when validation fails

# What has changed
Use new validateRowWithDataExcludedErrorMsgs function to get just that

# How to test?
Throw some invalid msgs at caseprocessor new case, sample/sensitive update.  Do you see field, rule and failure reason but not data thrown as exception?


# Links
https://trello.com/c/qshvggpc/2990-enhance-logging-on-validation-errors-when-creating-updating-a-case-5
