### PR TITLE
Differentiate between fulfilments and action rule sends in event log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.12.4-SNAPSHOT</version>
+      <version>4.12.5-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/MessageConsumerConfig.java
@@ -55,11 +55,11 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.update-sample-sensitive-subscription}")
   private String updateSampleSensitiveSubscription;
 
-  @Value("${queueconfig.sms-fulfilment-subscription}")
-  private String smsFulfilmentSubscription;
+  @Value("${queueconfig.sms-confirmation-subscription}")
+  private String smsConfirmationSubscription;
 
-  @Value("${queueconfig.email-fulfilment-subscription}")
-  private String emailFulfilmentSubscription;
+  @Value("${queueconfig.email-confirmation-subscription}")
+  private String emailConfirmationSubscription;
 
   public MessageConsumerConfig(
       ManagedMessageRecoverer managedMessageRecoverer, PubSubTemplate pubSubTemplate) {
@@ -123,12 +123,12 @@ public class MessageConsumerConfig {
   }
 
   @Bean
-  public MessageChannel smsFulfilmentInputChannel() {
+  public MessageChannel smsConfirmationInputChannel() {
     return new DirectChannel();
   }
 
   @Bean
-  public MessageChannel emailFulfilmentInputChannel() {
+  public MessageChannel emailConfirmationInputChannel() {
     return new DirectChannel();
   }
 
@@ -220,15 +220,15 @@ public class MessageConsumerConfig {
   }
 
   @Bean
-  PubSubInboundChannelAdapter smsFulfilmentInbound(
-      @Qualifier("smsFulfilmentInputChannel") MessageChannel channel) {
-    return makeAdapter(channel, smsFulfilmentSubscription);
+  PubSubInboundChannelAdapter smsConfirmationInbound(
+      @Qualifier("smsConfirmationInputChannel") MessageChannel channel) {
+    return makeAdapter(channel, smsConfirmationSubscription);
   }
 
   @Bean
-  PubSubInboundChannelAdapter emailFulfilmentInbound(
-      @Qualifier("emailFulfilmentInputChannel") MessageChannel channel) {
-    return makeAdapter(channel, emailFulfilmentSubscription);
+  PubSubInboundChannelAdapter emailConfirmationInbound(
+      @Qualifier("emailConfirmationInputChannel") MessageChannel channel) {
+    return makeAdapter(channel, emailConfirmationSubscription);
   }
 
   private PubSubInboundChannelAdapter makeAdapter(MessageChannel channel, String subscriptionName) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailConfirmation.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailConfirmation.java
@@ -4,10 +4,11 @@ import java.util.UUID;
 import lombok.Data;
 
 @Data
-public class EnrichedSmsFulfilment {
+public class EmailConfirmation {
   private UUID caseId;
   private String packCode;
   private String uac;
   private String qid;
   private Object uacMetadata;
+  private boolean scheduled;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailRequest.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailRequest.java
@@ -12,4 +12,6 @@ public class EmailRequest {
   private String packCode;
 
   private Object uacMetadata;
+
+  private boolean scheduled;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
@@ -19,8 +19,8 @@ public class PayloadDTO {
   private UpdateSample updateSample;
   private EqLaunchDTO eqLaunch;
   private UacAuthenticationDTO uacAuthentication;
-  private EnrichedSmsFulfilment enrichedSmsFulfilment;
-  private EnrichedEmailFulfilment enrichedEmailFulfilment;
+  private SmsConfirmation smsConfirmation;
+  private EmailConfirmation emailConfirmation;
   private NewCase newCase;
   private SmsRequest smsRequest;
   private EmailRequest emailRequest;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/SmsConfirmation.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/SmsConfirmation.java
@@ -4,10 +4,11 @@ import java.util.UUID;
 import lombok.Data;
 
 @Data
-public class EnrichedEmailFulfilment {
+public class SmsConfirmation {
   private UUID caseId;
   private String packCode;
   private String uac;
   private String qid;
   private Object uacMetadata;
+  private boolean scheduled;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/SmsRequest.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/SmsRequest.java
@@ -12,4 +12,6 @@ public class SmsRequest {
   private String packCode;
 
   private Object uacMetadata;
+
+  private boolean scheduled;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EmailProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EmailProcessor.java
@@ -38,6 +38,7 @@ public class EmailProcessor {
     emailRequest.setPackCode(packCode);
     emailRequest.setEmail(email);
     emailRequest.setUacMetadata(actionRule.getUacMetadata());
+    emailRequest.setScheduled(true);
 
     EventHeaderDTO eventHeader =
         EventHelper.createEventDTO(

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/SmsProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/SmsProcessor.java
@@ -38,6 +38,7 @@ public class SmsProcessor {
     smsRequest.setPackCode(packCode);
     smsRequest.setPhoneNumber(phoneNumber);
     smsRequest.setUacMetadata(actionRule.getUacMetadata());
+    smsRequest.setScheduled(true);
 
     EventHeaderDTO eventHeader =
         EventHelper.createEventDTO(smsRequestTopic, actionRule.getId(), actionRule.getCreatedBy());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,8 +38,8 @@ spring:
 
 queueconfig:
   telephone-capture-subscription: rm-internal-telephone-capture_case-processor
-  sms-fulfilment-subscription: rm-internal-sms-fulfilment_case-processor
-  email-fulfilment-subscription: rm-internal-email-fulfilment_case-processor
+  sms-confirmation-subscription: rm-internal-sms-confirmation_case-processor
+  email-confirmation-subscription: rm-internal-email-confirmation_case-processor
   new-case-subscription: event_new-case_rm-case-processor
   receipt-subscription: event_receipt_rm-case-processor
   refusal-subscription: event_refusal_rm-case-processor

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.EMAIL_FULFILMENT_TOPIC;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.EMAIL_CONFIRMATION_TOPIC;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
@@ -17,7 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.ons.ssdc.caseprocessor.client.UacQidServiceClient;
-import uk.gov.ons.ssdc.caseprocessor.model.dto.EnrichedEmailFulfilment;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EmailConfirmation;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
@@ -69,19 +69,19 @@ class EmailFulfilmentReceiverIT {
     Case testCase = junkDataHelper.setupJunkCase();
 
     // Build the event message
-    EnrichedEmailFulfilment enrichedEmailFulfilment = new EnrichedEmailFulfilment();
-    enrichedEmailFulfilment.setUac(emailUacQid.getUac());
-    enrichedEmailFulfilment.setQid(emailUacQid.getQid());
-    enrichedEmailFulfilment.setCaseId(testCase.getId());
-    enrichedEmailFulfilment.setPackCode(PACK_CODE);
-    enrichedEmailFulfilment.setUacMetadata(TEST_UAC_METADATA);
+    EmailConfirmation emailConfirmation = new EmailConfirmation();
+    emailConfirmation.setUac(emailUacQid.getUac());
+    emailConfirmation.setQid(emailUacQid.getQid());
+    emailConfirmation.setCaseId(testCase.getId());
+    emailConfirmation.setPackCode(PACK_CODE);
+    emailConfirmation.setUacMetadata(TEST_UAC_METADATA);
 
     PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setEnrichedEmailFulfilment(enrichedEmailFulfilment);
+    payloadDTO.setEmailConfirmation(emailConfirmation);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
-    eventHeader.setTopic(EMAIL_FULFILMENT_TOPIC);
+    eventHeader.setTopic(EMAIL_CONFIRMATION_TOPIC);
     junkDataHelper.junkify(eventHeader);
 
     EventDTO event = new EventDTO();
@@ -90,7 +90,7 @@ class EmailFulfilmentReceiverIT {
 
     try (QueueSpy<EventDTO> outboundUacQueueSpy =
         pubsubHelper.sharedProjectListen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
-      pubsubHelper.sendMessage(EMAIL_FULFILMENT_TOPIC, event);
+      pubsubHelper.sendMessage(EMAIL_CONFIRMATION_TOPIC, event);
       EventDTO emittedEvent = outboundUacQueueSpy.checkExpectedMessageReceived();
 
       assertThat(emittedEvent.getHeader().getTopic()).isEqualTo(uacUpdateTopic);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
-import uk.gov.ons.ssdc.caseprocessor.model.dto.EnrichedEmailFulfilment;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EmailConfirmation;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
@@ -161,23 +161,23 @@ class EmailFulfilmentReceiverTest {
 
   private EventDTO buildEnrichedEmailFulfilmentEventWithUacQid() {
     EventDTO event = buildEnrichedEmailFulfilmentEvent();
-    event.getPayload().getEnrichedEmailFulfilment().setUac(TEST_UAC);
-    event.getPayload().getEnrichedEmailFulfilment().setQid(TEST_QID);
+    event.getPayload().getEmailConfirmation().setUac(TEST_UAC);
+    event.getPayload().getEmailConfirmation().setQid(TEST_QID);
     return event;
   }
 
   private EventDTO buildEnrichedEmailFulfilmentEvent() {
-    EnrichedEmailFulfilment enrichedEmailFulfilment = new EnrichedEmailFulfilment();
-    enrichedEmailFulfilment.setCaseId(CASE_ID);
-    enrichedEmailFulfilment.setPackCode(PACK_CODE);
-    enrichedEmailFulfilment.setUacMetadata(TEST_UAC_METADATA);
+    EmailConfirmation emailConfirmation = new EmailConfirmation();
+    emailConfirmation.setCaseId(CASE_ID);
+    emailConfirmation.setPackCode(PACK_CODE);
+    emailConfirmation.setUacMetadata(TEST_UAC_METADATA);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setEnrichedEmailFulfilment(enrichedEmailFulfilment);
+    payloadDTO.setEmailConfirmation(emailConfirmation);
 
     EventDTO event = new EventDTO();
     event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.OUTBOUND_UAC_SUBSCRIPTION;
-import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.SMS_FULFILMENT_TOPIC;
+import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.SMS_CONFIRMATION_TOPIC;
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import java.util.List;
@@ -17,10 +17,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.ons.ssdc.caseprocessor.client.UacQidServiceClient;
-import uk.gov.ons.ssdc.caseprocessor.model.dto.EnrichedSmsFulfilment;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.SmsConfirmation;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.UacQidDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.UacUpdateDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.UacQidLinkRepository;
@@ -69,19 +69,19 @@ class SmsFulfilmentReceiverIT {
     Case testCase = junkDataHelper.setupJunkCase();
 
     // Build the event message
-    EnrichedSmsFulfilment enrichedSmsFulfilment = new EnrichedSmsFulfilment();
-    enrichedSmsFulfilment.setUac(smsUacQid.getUac());
-    enrichedSmsFulfilment.setQid(smsUacQid.getQid());
-    enrichedSmsFulfilment.setCaseId(testCase.getId());
-    enrichedSmsFulfilment.setPackCode(PACK_CODE);
-    enrichedSmsFulfilment.setUacMetadata(TEST_UAC_METADATA);
+    SmsConfirmation smsConfirmation = new SmsConfirmation();
+    smsConfirmation.setUac(smsUacQid.getUac());
+    smsConfirmation.setQid(smsUacQid.getQid());
+    smsConfirmation.setCaseId(testCase.getId());
+    smsConfirmation.setPackCode(PACK_CODE);
+    smsConfirmation.setUacMetadata(TEST_UAC_METADATA);
 
     PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setEnrichedSmsFulfilment(enrichedSmsFulfilment);
+    payloadDTO.setSmsConfirmation(smsConfirmation);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
-    eventHeader.setTopic(SMS_FULFILMENT_TOPIC);
+    eventHeader.setTopic(SMS_CONFIRMATION_TOPIC);
     junkDataHelper.junkify(eventHeader);
 
     EventDTO event = new EventDTO();
@@ -90,7 +90,7 @@ class SmsFulfilmentReceiverIT {
 
     try (QueueSpy<EventDTO> outboundUacQueueSpy =
         pubsubHelper.sharedProjectListen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
-      pubsubHelper.sendMessage(SMS_FULFILMENT_TOPIC, event);
+      pubsubHelper.sendMessage(SMS_CONFIRMATION_TOPIC, event);
       EventDTO emittedEvent = outboundUacQueueSpy.checkExpectedMessageReceived();
 
       assertThat(emittedEvent.getHeader().getTopic()).isEqualTo(uacUpdateTopic);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
@@ -22,10 +22,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
-import uk.gov.ons.ssdc.caseprocessor.model.dto.EnrichedSmsFulfilment;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.SmsConfirmation;
 import uk.gov.ons.ssdc.caseprocessor.service.CaseService;
 import uk.gov.ons.ssdc.caseprocessor.service.UacService;
 import uk.gov.ons.ssdc.common.model.entity.Case;
@@ -153,23 +153,23 @@ class SmsFulfilmentReceiverTest {
 
   private EventDTO buildEnrichedSmsFulfilmentEventWithUacQid() {
     EventDTO event = buildEnrichedSmsFulfilmentEvent();
-    event.getPayload().getEnrichedSmsFulfilment().setUac(TEST_UAC);
-    event.getPayload().getEnrichedSmsFulfilment().setQid(TEST_QID);
+    event.getPayload().getSmsConfirmation().setUac(TEST_UAC);
+    event.getPayload().getSmsConfirmation().setQid(TEST_QID);
     return event;
   }
 
   private EventDTO buildEnrichedSmsFulfilmentEvent() {
-    EnrichedSmsFulfilment enrichedSmsFulfilment = new EnrichedSmsFulfilment();
-    enrichedSmsFulfilment.setCaseId(CASE_ID);
-    enrichedSmsFulfilment.setPackCode(PACK_CODE);
-    enrichedSmsFulfilment.setUacMetadata(TEST_UAC_METADATA);
+    SmsConfirmation smsConfirmation = new SmsConfirmation();
+    smsConfirmation.setCaseId(CASE_ID);
+    smsConfirmation.setPackCode(PACK_CODE);
+    smsConfirmation.setUacMetadata(TEST_UAC_METADATA);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setCorrelationId(TEST_CORRELATION_ID);
     eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
     PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setEnrichedSmsFulfilment(enrichedSmsFulfilment);
+    payloadDTO.setSmsConfirmation(smsConfirmation);
 
     EventDTO event = new EventDTO();
     event.setHeader(eventHeader);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConstants.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/testutils/TestConstants.java
@@ -14,8 +14,8 @@ public class TestConstants {
       "rm-internal-email-request-enriched_notify-service";
 
   public static final String TELEPHONE_CAPTURE_TOPIC = "rm-internal-telephone-capture";
-  public static final String SMS_FULFILMENT_TOPIC = "rm-internal-sms-fulfilment";
-  public static final String EMAIL_FULFILMENT_TOPIC = "rm-internal-email-fulfilment";
+  public static final String SMS_CONFIRMATION_TOPIC = "rm-internal-sms-confirmation";
+  public static final String EMAIL_CONFIRMATION_TOPIC = "rm-internal-email-confirmation";
 
   public static final UUID TEST_CORRELATION_ID = UUID.randomUUID();
   public static final String TEST_ORIGINATING_USER = "foo@bar.com";

--- a/src/test/resources/setup_pubsub.sh
+++ b/src/test/resources/setup_pubsub.sh
@@ -9,14 +9,14 @@ curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-i
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-sms-request
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-sms-request-enriched_notify-service -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-sms-request"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-sms-fulfilment
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-sms-fulfilment_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-sms-fulfilment"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-sms-confirmation
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-sms-confirmation_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-sms-confirmation"}'
 
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-email-request
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-email-request-enriched_notify-service -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-email-request"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-email-fulfilment
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-email-fulfilment_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-email-fulfilment"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-email-confirmation
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-email-confirmation_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-email-confirmation"}'
 
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_new-case
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_new-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_new-case"}'


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Emails and sms from fulfilments and action rules are recorded the same in the event log. We want to be able to differentiate between these.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
New flag added to dtos to mark if the email or sms is being sent as part of an action rule. This is sent as part of the message to notify service.
When the notify service has confirmed the message has been sent, the case processor records the event differently depending if it was fulfilment or action rule if the flag is present.
Renaming of return queue from notify service to confirmation from being named specifically fulfilment.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and make up with all other branches on card.
Run ATs
Check the emails and sms sent using action rules are recorded in the event log with the types ACTION_RULE_SMS_CONFIRMATION/ACTION_RULE_EMAIL_CONFIRMATION.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/icUNfLJQ/3057-can-we-differentiate-between-fulfilment-requests-and-action-rule-sends-in-event-log-for-sms-email-8
# Screenshots (if appropriate):
