### PR TITLE
3227 - Add caseRef to case update events

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.caseprocessor.model.dto;
 
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
@@ -14,4 +15,6 @@ public class CaseUpdateDTO {
   private RefusalTypeDTO refusalReceived;
   private Map<String, String> sample;
   private Map<String, String> sampleSensitive;
+  private OffsetDateTime createdAt;
+  private OffsetDateTime lastUpdatedAt;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CaseUpdateDTO.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Data
 public class CaseUpdateDTO {
   private UUID caseId;
+  private String caseRef;
   private UUID collectionExerciseId;
   private UUID surveyId;
   private boolean invalid;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -56,6 +56,7 @@ public class CaseService {
     PayloadDTO payloadDTO = new PayloadDTO();
     CaseUpdateDTO caseUpdate = new CaseUpdateDTO();
     caseUpdate.setCaseId(caze.getId());
+    caseUpdate.setCaseRef(Long.toString(caze.getCaseRef()));
     caseUpdate.setCollectionExerciseId(caze.getCollectionExercise().getId());
     caseUpdate.setSurveyId(caze.getCollectionExercise().getSurvey().getId());
     caseUpdate.setSample(caze.getSample());

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseService.java
@@ -60,6 +60,8 @@ public class CaseService {
     caseUpdate.setCollectionExerciseId(caze.getCollectionExercise().getId());
     caseUpdate.setSurveyId(caze.getCollectionExercise().getSurvey().getId());
     caseUpdate.setSample(caze.getSample());
+    caseUpdate.setCreatedAt(caze.getCreatedAt());
+    caseUpdate.setLastUpdatedAt(caze.getLastUpdatedAt());
 
     caseUpdate.setInvalid(caze.isInvalid());
     if (caze.getRefusalReceived() != null) {

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiverIT.java
@@ -45,6 +45,7 @@ import uk.gov.ons.ssdc.common.validation.Rule;
 public class UpdateSampleReceiverIT {
 
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
+  private static final Long TEST_CASE_REF = 1234567890L;
   private static final ObjectMapper objectMapper = ObjectMapperFactory.objectMapper();
   private static final String UPDATE_SAMPLE_TOPIC = "event_update-sample";
 
@@ -67,6 +68,7 @@ public class UpdateSampleReceiverIT {
 
     Case caze = new Case();
     caze.setId(TEST_CASE_ID);
+    caze.setCaseRef(TEST_CASE_REF);
     Map<String, String> sampleData = new HashMap<>();
     sampleData.put("testSampleField", "Test");
     caze.setSample(sampleData);
@@ -105,6 +107,7 @@ public class UpdateSampleReceiverIT {
     // Given
     Case caze = new Case();
     caze.setId(TEST_CASE_ID);
+    caze.setCaseRef(TEST_CASE_REF);
     Map<String, String> sampleData = new HashMap<>();
     sampleData.put("testSampleFieldA", "Original value");
     sampleData.put("testSampleFieldB", "Original value");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiverIT.java
@@ -49,6 +49,7 @@ public class UpdateSampleSensitiveReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
   private static final ObjectMapper objectMapper = ObjectMapperFactory.objectMapper();
   private static final String UPDATE_SAMPLE_SENSITIVE_TOPIC = "event_update-sample-sensitive";
+  private static final Long TEST_CASE_REF = 1234567890L;
 
   @Value("${queueconfig.case-update-topic}")
   private String caseUpdateTopic;
@@ -76,6 +77,7 @@ public class UpdateSampleSensitiveReceiverIT {
 
       Case caze = new Case();
       caze.setId(TEST_CASE_ID);
+      caze.setCaseRef(TEST_CASE_REF);
       caze.setSampleSensitive(Map.of("SensitiveJunk", "02071234567"));
       caze.setCollectionExercise(junkDataHelper.setupJunkCollex());
       caseRepository.saveAndFlush(caze);
@@ -115,6 +117,7 @@ public class UpdateSampleSensitiveReceiverIT {
     // Given
     Case caze = new Case();
     caze.setId(TEST_CASE_ID);
+    caze.setCaseRef(TEST_CASE_REF);
     Map<String, String> sensitiveData = new HashMap<>();
     sensitiveData.put("sensitiveA", "Original value");
     sensitiveData.put("sensitiveB", "Original value");

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
@@ -48,6 +48,7 @@ public class CaseServiceTest {
 
     Case caze = new Case();
     caze.setId(UUID.randomUUID());
+    caze.setCaseRef(1234567890L);
     caze.setCollectionExercise(collex);
     caze.setSample(Map.of("foo", "bar"));
     caze.setSampleSensitive(Map.of("Top", "Secret"));
@@ -68,6 +69,7 @@ public class CaseServiceTest {
 
     CaseUpdateDTO actualCaseUpdate = actualEvent.getPayload().getCaseUpdate();
     assertThat(actualCaseUpdate.getCaseId()).isEqualTo(caze.getId());
+    assertThat(actualCaseUpdate.getCaseRef()).isEqualTo(caze.getCaseRef().toString());
     assertThat(actualCaseUpdate.getCollectionExerciseId()).isEqualTo(collex.getId());
     assertThat(actualCaseUpdate.getSurveyId()).isEqualTo(survey.getId());
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());
@@ -84,7 +86,7 @@ public class CaseServiceTest {
   }
 
   @Test
-  public void emitCaseCreatedEvent() {
+  public void emitCaseUpdatedEvent() {
     ReflectionTestUtils.setField(underTest, "caseUpdateTopic", "Test topic");
     ReflectionTestUtils.setField(underTest, "sharedPubsubProject", "Test project");
 
@@ -96,6 +98,7 @@ public class CaseServiceTest {
 
     Case caze = new Case();
     caze.setId(UUID.randomUUID());
+    caze.setCaseRef(1234567890L);
     caze.setCollectionExercise(collex);
     caze.setSample(Map.of("foo", "bar"));
     caze.setInvalid(true);
@@ -114,6 +117,7 @@ public class CaseServiceTest {
 
     CaseUpdateDTO actualCaseUpdate = actualEvent.getPayload().getCaseUpdate();
     assertThat(actualCaseUpdate.getCaseId()).isEqualTo(caze.getId());
+    assertThat(actualCaseUpdate.getCaseRef()).isEqualTo(caze.getCaseRef().toString());
     assertThat(actualCaseUpdate.getCollectionExerciseId()).isEqualTo(collex.getId());
     assertThat(actualCaseUpdate.getSurveyId()).isEqualTo(survey.getId());
     assertThat(actualCaseUpdate.getSample()).isEqualTo(caze.getSample());

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/CaseServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
 import static uk.gov.ons.ssdc.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
 
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -103,6 +104,8 @@ public class CaseServiceTest {
     caze.setSample(Map.of("foo", "bar"));
     caze.setInvalid(true);
     caze.setRefusalReceived(RefusalType.EXTRAORDINARY_REFUSAL);
+    caze.setCreatedAt(OffsetDateTime.now().minusSeconds(10));
+    caze.setLastUpdatedAt(OffsetDateTime.now());
 
     underTest.emitCaseUpdate(caze, TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
 
@@ -124,6 +127,8 @@ public class CaseServiceTest {
     assertThat(actualCaseUpdate.isInvalid()).isTrue();
     assertThat(actualCaseUpdate.getRefusalReceived())
         .isEqualTo(RefusalTypeDTO.EXTRAORDINARY_REFUSAL);
+    assertThat(actualCaseUpdate.getCreatedAt()).isEqualTo(caze.getCreatedAt());
+    assertThat(actualCaseUpdate.getLastUpdatedAt()).isEqualTo(caze.getLastUpdatedAt());
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
RM need to include the `caseRef`, `createdAt`, and `lastUpdatedAt` in `caseUpdate` messages (see [event dictionary](https://github.com/ONSdigital/ssdc-shared-events/blob/main/event_dictionary/0.5.0/caseUpdate.schema.json))

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added extra fields to caseUpdateDTO and populate.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Should still pass with ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/TBFVcPSY/3227-we-are-not-sending-caseref-as-part-of-the-eventcase-update