### PR TITLE
Store and use request fields on fulfilments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.13.0-SNAPSHOT</version>
+      <version>4.14.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
@@ -112,18 +112,18 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-55</artifactId>
-      <version>2.12.1</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>1.6</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>com.godaddy</groupId>
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>4.1</version>
+      <version>4.6</version>
     </dependency>
 
     <!-- Test Dependencies below this point -->

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiver.java
@@ -48,6 +48,8 @@ public class PrintFulfilmentReceiver {
     fulfilmentToProcess.setCorrelationId(event.getHeader().getCorrelationId());
     fulfilmentToProcess.setOriginatingUser(event.getHeader().getOriginatingUser());
     fulfilmentToProcess.setUacMetadata(event.getPayload().getPrintFulfilment().getUacMetadata());
+    fulfilmentToProcess.setPersonalisation(
+        event.getPayload().getPrintFulfilment().getPersonalisation());
 
     fulfilmentToProcessRepository.saveAndFlush(fulfilmentToProcess);
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PrintFulfilmentDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PrintFulfilmentDTO.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.caseprocessor.model.dto;
 
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 
@@ -8,4 +9,5 @@ public class PrintFulfilmentDTO {
   private UUID caseId;
   private String packCode;
   private Object uacMetadata;
+  private Map<String, String> personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
@@ -6,4 +6,6 @@ public class Constants {
   public static final String OUTBOUND_EVENT_SCHEMA_VERSION = "0.5.0";
   public static final Set<String> ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS =
       Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0", "0.5.0-DRAFT", "0.5.0", "0.6.0-DRAFT");
+
+  public static final String REQUEST_PERSONALISATION_PREFIX = "__request__.";
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/RedactHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/RedactHelper.java
@@ -21,7 +21,8 @@ public class RedactHelper {
     new ThingToRedact("getSampleSensitive", Map.class),
     new ThingToRedact("setUac", String.class),
     new ThingToRedact("setPhoneNumber", String.class),
-    new ThingToRedact("setEmail", String.class)
+    new ThingToRedact("setEmail", String.class),
+    new ThingToRedact("getPersonalisation", Map.class)
   };
 
   public static Object redact(Object rootObjectToRedact) {
@@ -73,6 +74,9 @@ public class RedactHelper {
         && method.getReturnType().equals(Map.class)) {
       try {
         Map<String, String> sensitiveData = (Map<String, String>) method.invoke(object);
+        if (sensitiveData == null) {
+          return;
+        }
         for (String key : sensitiveData.keySet()) {
           if (StringUtils.hasText((sensitiveData.get(key)))) {
             sensitiveData.put(key, REDACTION_TEXT);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/PrintFulfilmentReceiverTest.java
@@ -12,6 +12,7 @@ import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEM
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +62,10 @@ class PrintFulfilmentReceiverTest {
     managementEvent.getPayload().getPrintFulfilment().setCaseId(UUID.randomUUID());
     managementEvent.getPayload().getPrintFulfilment().setPackCode(PACK_CODE);
     managementEvent.getPayload().getPrintFulfilment().setUacMetadata(TEST_UAC_METADATA);
+    managementEvent
+        .getPayload()
+        .getPrintFulfilment()
+        .setPersonalisation(Map.of("name", "Joe Bloggs"));
     Message<byte[]> message = constructMessage(managementEvent);
 
     ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
@@ -90,6 +95,7 @@ class PrintFulfilmentReceiverTest {
     assertThat(fulfilmentToProcess.getExportFileTemplate()).isEqualTo(exportFileTemplate);
     assertThat(fulfilmentToProcess.getCaze()).isEqualTo(expectedCase);
     assertThat(fulfilmentToProcess.getUacMetadata()).isEqualTo(TEST_UAC_METADATA);
+    assertThat(fulfilmentToProcess.getPersonalisation()).containsEntry("name", "Joe Bloggs");
 
     verify(eventLogger)
         .logCaseEvent(


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to enable print fulfilment requests to supply extra personalisation values beyond what is stored on the case. We need to store those request personalisation values in the fulfilment to process table, then populate the resulting export file row when the fulfilment is processed.

# What has changed
- Store personalisation json in fulfilment to process
- Add personalisation to the fulfilment export file row when processing
- Add personalisation to redact helper so the data fields are redacted from the event log

# How to test?
Build the service branches and run the AT's.

# Links
https://trello.com/c/fwLbkDJy/3209-ability-to-include-a-name-on-a-fulfilment-by-post-8
