### PR TITLE
3245 Fix fulfilment personalisation null bug

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
@@ -132,10 +132,9 @@ public class ExportFileProcessor {
           break;
         default:
           if (templateItem.startsWith(REQUEST_PERSONALISATION_PREFIX)) {
-            rowStrings[i] =
+            rowStrings[i] = personalisation != null ?
                 personalisation.get(
-                    templateItem.substring(REQUEST_PERSONALISATION_PREFIX.length()));
-
+                    templateItem.substring(REQUEST_PERSONALISATION_PREFIX.length())) : null;
           } else {
             rowStrings[i] = caze.getSample().get(templateItem);
           }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
@@ -132,9 +132,11 @@ public class ExportFileProcessor {
           break;
         default:
           if (templateItem.startsWith(REQUEST_PERSONALISATION_PREFIX)) {
-            rowStrings[i] = personalisation != null ?
-                personalisation.get(
-                    templateItem.substring(REQUEST_PERSONALISATION_PREFIX.length())) : null;
+            rowStrings[i] =
+                personalisation != null
+                    ? personalisation.get(
+                        templateItem.substring(REQUEST_PERSONALISATION_PREFIX.length()))
+                    : null;
           } else {
             rowStrings[i] = caze.getSample().get(templateItem);
           }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
@@ -250,7 +250,8 @@ class ExportFileProcessorTest {
     ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
     exportFileTemplate.setPackCode(PACK_CODE);
     exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
-    exportFileTemplate.setTemplate(new String[] {"__caseref__", "__uac__", "__request__.foo", "__request__.spam"});
+    exportFileTemplate.setTemplate(
+        new String[] {"__caseref__", "__uac__", "__request__.foo", "__request__.spam"});
 
     Case caze = new Case();
     caze.setSample(Map.of("foo", "bar"));
@@ -264,7 +265,7 @@ class ExportFileProcessorTest {
     fulfilmentToProcess.setCorrelationId(TEST_CORRELATION_ID);
     fulfilmentToProcess.setOriginatingUser(TEST_ORIGINATING_USER);
     fulfilmentToProcess.setUacMetadata(TEST_UAC_METADATA);
-    fulfilmentToProcess.setPersonalisation(Map.of("foo","bar", "spam", "eggs"));
+    fulfilmentToProcess.setPersonalisation(Map.of("foo", "bar", "spam", "eggs"));
 
     UacQidDTO uacQidDTO = new UacQidDTO();
     uacQidDTO.setUac(UAC);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`peronalisation` can be `null` on valid fulfilment requests, this was causing a null pointer exception when the fulfilment was processed to send

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Allow null personalisation
- Add test cases

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Follow the instructions on the support tool PR, send in a request for a template which has `__request__.` parameters but leave them empty. Trigger fulfilments to send. They should be processed without error even with `null` personalisation.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dCFLqaY4/3245-support-tool-personalisation-on-print-fulfilment-requests-8