### PR TITLE
3266 manage case withdrawals and data removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.14.0-SNAPSHOT</version>
+      <version>4.15.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
@@ -35,6 +35,7 @@ public class RefusalReceiver {
 
     if (refusal.isEraseData()) {
       refusedCase.setSampleSensitive(null);
+      refusedCase.setInvalid(true);
       eventLogger.logCaseEvent(
           refusedCase, "Data erasure request received", EventType.ERASE_DATA, event, message);
     }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiver.java
@@ -33,6 +33,11 @@ public class RefusalReceiver {
     Case refusedCase = caseService.getCase(refusal.getCaseId());
     refusedCase.setRefusalReceived(RefusalType.valueOf(refusal.getType().name()));
 
+    if (refusal.isEraseData()) {
+      refusedCase.setSampleSensitive(null);
+      eventLogger.logCaseEvent(
+          refusedCase, "Data erasure request received", EventType.ERASE_DATA, event, message);
+    }
     caseService.saveCaseAndEmitCaseUpdate(
         refusedCase, event.getHeader().getCorrelationId(), event.getHeader().getOriginatingUser());
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/RefusalDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/RefusalDTO.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class RefusalDTO {
   private UUID caseId;
   private RefusalTypeDTO type;
+  private boolean eraseData;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/RefusalTypeDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/RefusalTypeDTO.java
@@ -3,5 +3,6 @@ package uk.gov.ons.ssdc.caseprocessor.model.dto;
 public enum RefusalTypeDTO {
   HARD_REFUSAL,
   EXTRAORDINARY_REFUSAL,
-  SOFT_REFUSAL
+  SOFT_REFUSAL,
+  WITHDRAWAL_REFUSAL
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
@@ -111,9 +111,10 @@ public class RefusalReceiverIT {
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);
 
+      // WHEN
       pubsubHelper.sendMessageToSharedProject(INBOUND_REFUSAL_TOPIC, event);
 
-      //  THEN
+      // THEN
       EventDTO actualEvent = outboundCaseQueueSpy.checkExpectedMessageReceived();
 
       CaseUpdateDTO emittedCase = actualEvent.getPayload().getCaseUpdate();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
@@ -87,4 +87,47 @@ public class RefusalReceiverIT {
       assertThat(databaseEvent.getType()).isEqualTo(EventType.REFUSAL);
     }
   }
+
+  @Test
+  public void testRefusalWithErasure() throws Exception {
+    try (QueueSpy<EventDTO> outboundCaseQueueSpy =
+        pubsubHelper.sharedProjectListen(OUTBOUND_CASE_SUBSCRIPTION, EventDTO.class)) {
+      // GIVEN
+
+      Case caze = junkDataHelper.setupJunkCase();
+
+      RefusalDTO refusalDTO = new RefusalDTO();
+      refusalDTO.setCaseId(caze.getId());
+      refusalDTO.setType(RefusalTypeDTO.EXTRAORDINARY_REFUSAL);
+      refusalDTO.setEraseData(true);
+      PayloadDTO payloadDTO = new PayloadDTO();
+      payloadDTO.setRefusal(refusalDTO);
+      EventDTO event = new EventDTO();
+      event.setPayload(payloadDTO);
+
+      EventHeaderDTO eventHeader = new EventHeaderDTO();
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+      eventHeader.setTopic(INBOUND_REFUSAL_TOPIC);
+      junkDataHelper.junkify(eventHeader);
+      event.setHeader(eventHeader);
+
+      pubsubHelper.sendMessageToSharedProject(INBOUND_REFUSAL_TOPIC, event);
+
+      //  THEN
+      EventDTO actualEvent = outboundCaseQueueSpy.checkExpectedMessageReceived();
+
+      CaseUpdateDTO emittedCase = actualEvent.getPayload().getCaseUpdate();
+      assertThat(emittedCase.getCaseId()).isEqualTo(caze.getId());
+      assertThat(emittedCase.getRefusalReceived()).isEqualTo(RefusalTypeDTO.EXTRAORDINARY_REFUSAL);
+      assertThat(emittedCase.getSampleSensitive()).isNull();
+
+      assertThat(eventRepository.findAll().size()).isEqualTo(2);
+      Event databaseRefusalEvent = eventRepository.findAll().get(1);
+      assertThat(databaseRefusalEvent.getCaze().getId()).isEqualTo(caze.getId());
+      assertThat(databaseRefusalEvent.getType()).isEqualTo(EventType.REFUSAL);
+      Event databaseDataErasureEvent = eventRepository.findAll().get(0);
+      assertThat(databaseDataErasureEvent.getCaze().getId()).isEqualTo(caze.getId());
+      assertThat(databaseDataErasureEvent.getType()).isEqualTo(EventType.ERASE_DATA);
+    }
+  }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverIT.java
@@ -121,6 +121,7 @@ public class RefusalReceiverIT {
       assertThat(emittedCase.getCaseId()).isEqualTo(caze.getId());
       assertThat(emittedCase.getRefusalReceived()).isEqualTo(RefusalTypeDTO.EXTRAORDINARY_REFUSAL);
       assertThat(emittedCase.getSampleSensitive()).isNull();
+      assertThat(emittedCase.isInvalid()).isTrue();
 
       assertThat(eventRepository.findAll().size()).isEqualTo(2);
       Event databaseRefusalEvent = eventRepository.findAll().get(1);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
@@ -130,6 +130,7 @@ public class RefusalReceiverTest {
     assertThat(actualCase.getId()).isEqualTo(CASE_ID);
     assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.WITHDRAWAL_REFUSAL);
     assertThat(actualCase.getSampleSensitive()).isNull();
+    assertThat(actualCase.isInvalid()).isTrue();
 
     verify(eventLogger)
         .logCaseEvent(
@@ -185,6 +186,7 @@ public class RefusalReceiverTest {
     assertThat(actualCase.getId()).isEqualTo(CASE_ID);
     assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.HARD_REFUSAL);
     assertThat(actualCase.getSampleSensitive()).isEqualTo(Map.of("testing", "erasure"));
+    assertThat(actualCase.isInvalid()).isFalse();
 
     verify(eventLogger)
         .logCaseEvent(

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/RefusalReceiverTest.java
@@ -11,6 +11,7 @@ import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEM
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,6 +113,7 @@ public class RefusalReceiverTest {
     Case caze = new Case();
     caze.setId(CASE_ID);
     caze.setRefusalReceived(null);
+    caze.setSampleSensitive(Map.of("testing", "erasure"));
 
     when(caseService.getCase(CASE_ID)).thenReturn(caze);
 
@@ -139,5 +141,53 @@ public class RefusalReceiverTest {
             eq(EventType.ERASE_DATA),
             eq(event),
             eq(message));
+  }
+
+  @Test
+  public void testRefusalWithDataErasureFalse() {
+    // Given
+    RefusalDTO refusalDTO = new RefusalDTO();
+    refusalDTO.setCaseId(CASE_ID);
+    refusalDTO.setType(RefusalTypeDTO.HARD_REFUSAL);
+
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setRefusal(refusalDTO);
+
+    EventHeaderDTO eventHeader = new EventHeaderDTO();
+    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
+    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
+    eventHeader.setTopic("Test topic");
+    eventHeader.setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
+
+    EventDTO event = new EventDTO();
+    event.setPayload(payloadDTO);
+    event.setHeader(eventHeader);
+    Message<byte[]> message = constructMessage(event);
+
+    Case caze = new Case();
+    caze.setId(CASE_ID);
+    caze.setRefusalReceived(null);
+    caze.setSampleSensitive(Map.of("testing", "erasure"));
+
+    when(caseService.getCase(CASE_ID)).thenReturn(caze);
+
+    // When
+    underTest.receiveMessage(message);
+
+    // Then
+    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdate(
+            caseArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
+    Case actualCase = caseArgumentCaptor.getValue();
+
+    assertThat(actualCase.getId()).isEqualTo(CASE_ID);
+    assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.HARD_REFUSAL);
+    assertThat(actualCase.getSampleSensitive()).isEqualTo(Map.of("testing", "erasure"));
+
+    verify(eventLogger)
+        .logCaseEvent(
+            eq(caze), eq("Refusal Received"), eq(EventType.REFUSAL), eq(event), eq(message));
   }
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need a new refusal type for anyone whos previously agreed to take part in a survey but now wants to withdraw. We also need functionality to remove sensitive data if a respondent asks us to remove their data.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added new withdrawal refusal type
- Remove sensitive data through the refusal event.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with other branches and run the ATs
- Refuse a case and pass in `eraseData = true` and make sure the sensitive data in the event is removed
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/q8cx1tZn/)

