### PR TITLE
3277 - Add PMD and errorprone checks

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - IMAGE_NAME="$DOCKER_GCP_LOCATION/ssdc-rm-caseprocessor"
 
 before_install:
-  - mvn fmt:check
+  - mvn fmt:check pmd:check
   - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" https://europe-west2-docker.pkg.dev;
   - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";
   - docker network create ssdcrmdockerdev_default

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ format:
 format-check:
 	mvn fmt:check
 
+check:
+	mvn fmt:check pmd:check
+
 test:
 	mvn clean verify jacoco:report
 

--- a/exclude-pmd.properties
+++ b/exclude-pmd.properties
@@ -1,0 +1,12 @@
+# TODO: as a team, define our own custom PMD checker so that we don't have to keep adding piecemeal
+#       to this file
+
+uk.gov.ons.ssdc.caseprocessor.cache.UacQidCache=AccessorMethodGeneration, PreserveStackTrace
+uk.gov.ons.ssdc.caseprocessor.collectioninstrument.RulesCache=UseVarargs
+uk.gov.ons.ssdc.caseprocessor.messaging.ManagedMessageRecoverer=GuardLogStatement
+uk.gov.ons.ssdc.caseprocessor.messaging.NewCaseReceiver=UseVarargs
+uk.gov.ons.ssdc.caseprocessor.service.ExportFileProcessor=UseVarargs
+uk.gov.ons.ssdc.caseprocessor.utils.HashHelper=AvoidMessageDigestField
+uk.gov.ons.ssdc.caseprocessor.utils.LuhnHelper=PreserveStackTrace
+uk.gov.ons.ssdc.caseprocessor.utils.pseudorandom.PseudorandomNumberGenerator=AccessorMethodGeneration, AccessorClassGeneration
+uk.gov.ons.ssdc.caseprocessor.utils.pseudorandom.PseudorandomNumberGenerator$FPEEncryptor=AvoidMessageDigestField

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,29 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.16.0</version>
+        <configuration>
+          <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
+          <failurePriority>3</failurePriority>
+          <failOnViolation>true</failOnViolation>
+          <verbose>true</verbose>
+          <rulesets>
+            <ruleset>/category/java/bestpractices.xml</ruleset>
+            <ruleset>/category/java/security.xml</ruleset>
+          </rulesets>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>
@@ -266,6 +289,23 @@
         <configuration>
           <source>17</source>
           <target>17</target>
+          <encoding>UTF-8</encoding>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.11.0</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.22</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
           <verbose>true</verbose>
+          <linkXRef>false</linkXRef>
           <rulesets>
             <ruleset>/category/java/bestpractices.xml</ruleset>
             <ruleset>/category/java/security.xml</ruleset>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/config/AppConfig.java
@@ -47,7 +47,7 @@ public class AppConfig {
 
   @PostConstruct
   public void init() {
-    if (loggingProfile.equals("STRUCTURED")) {
+    if ("STRUCTURED".equals(loggingProfile)) {
       LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/ManagedMessageRecoverer.java
@@ -65,13 +65,7 @@ public class ManagedMessageRecoverer implements RecoveryCallback<Object> {
     ExceptionReportResponse reportResult =
         getExceptionReportResponse(cause, messageHash, stackTraceRootCause, subscriptionName);
 
-    if (skipMessage(
-        reportResult,
-        messageHash,
-        rawMessageBody,
-        retryContext.getLastThrowable(),
-        originalMessage,
-        subscriptionName)) {
+    if (skipMessage(reportResult, messageHash, rawMessageBody, subscriptionName)) {
       return null; // Our work here is done
     }
 
@@ -104,8 +98,6 @@ public class ManagedMessageRecoverer implements RecoveryCallback<Object> {
       ExceptionReportResponse reportResult,
       String messageHash,
       byte[] rawMessageBody,
-      Throwable cause,
-      BasicAcknowledgeablePubsubMessage originalMessage,
       String subscriptionName) {
 
     if (reportResult == null || !reportResult.isSkipIt()) {

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/NewCaseReceiver.java
@@ -152,11 +152,9 @@ public class NewCaseReceiver {
   }
 
   private Case saveNewCaseAndStampCaseRef(Case caze) {
-    caze = caseRepository.saveAndFlush(caze);
-    caze.setCaseRef(
-        CaseRefGenerator.getCaseRef(caze.getSecretSequenceNumber(), caserefgeneratorkey));
-    caze = caseRepository.saveAndFlush(caze);
-
-    return caze;
+    Case newCase = caseRepository.saveAndFlush(caze);
+    newCase.setCaseRef(
+        CaseRefGenerator.getCaseRef(newCase.getSecretSequenceNumber(), caserefgeneratorkey));
+    return caseRepository.saveAndFlush(newCase);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleReceiver.java
@@ -60,7 +60,7 @@ public class UpdateSampleReceiver {
       caze.getSample().put(entry.getKey(), entry.getValue());
     }
 
-    if (validationErrors.size() > 0) {
+    if (!validationErrors.isEmpty()) {
       throw new RuntimeException(
           EventType.UPDATE_SAMPLE
               + " event: "

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/messaging/UpdateSampleSensitiveReceiver.java
@@ -63,7 +63,7 @@ public class UpdateSampleSensitiveReceiver {
       caze.getSampleSensitive().put(columnName, newValue);
     }
 
-    if (validationErrors.size() > 0) {
+    if (!validationErrors.isEmpty()) {
       throw new RuntimeException(
           EventType.UPDATE_SAMPLE_SENSITIVE
               + " event: "

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/rasrm/client/RasRmPartyServiceClient.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/rasrm/client/RasRmPartyServiceClient.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ssdc.caseprocessor.rasrm.client;
 
 import static uk.gov.ons.ssdc.caseprocessor.rasrm.constants.RasRmConstants.BUSINESS_SAMPLE_UNIT_TYPE;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.codec.binary.Base64;
@@ -91,13 +91,13 @@ public class RasRmPartyServiceClient {
   }
 
   HttpHeaders createHeaders(String username, String password) {
-    return new HttpHeaders() {
-      {
-        String auth = username + ":" + password;
-        byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("US-ASCII")));
-        String authHeader = "Basic " + new String(encodedAuth);
-        set("Authorization", authHeader);
-      }
-    };
+    HttpHeaders headers = new HttpHeaders();
+
+    String auth = username + ":" + password;
+    byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.US_ASCII));
+    String authHeader = "Basic " + new String(encodedAuth);
+    headers.set("Authorization", authHeader);
+
+    return headers;
   }
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can introduce PMD and ErrorProne code analysis/compile tools to our Java apps. Drawing from [this spike branch](https://github.com/ONSdigital/ssdc-rm-response-operations/pull/78/files) and adding some additional bits.

I’ve put a `<failurePriority>`  of `3` for PMD (scale of 1 - 5, with `1` being 'severe'), so it will fail on anything over a medium level severity. Anything below this level will output as a warning. I’ve set it at a level that seems sensible, but it’s debatable!

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Add PMD ignore file for code to be ignored for now, but to investigate later 
* Fix some errors & warnings from PMD
* Add `check` target to Makefile
* Update Travis checks

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* If you want to see some of the PMD failures, comment out the lines in `exclude-pmd.propeties` file.
* Check to see the tools pick up the issues as expected.
* Run ATs, should still pass.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Y4aAAwHb/3277-java-checks-8