### PR TITLE
3246 Personalisation on SMS and email fulfilments

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailConfirmation.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EmailConfirmation.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.caseprocessor.model.dto;
 
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 
@@ -11,4 +12,5 @@ public class EmailConfirmation {
   private String qid;
   private Object uacMetadata;
   private boolean scheduled;
+  private Map<String, String> personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/SmsConfirmation.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/SmsConfirmation.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.caseprocessor.model.dto;
 
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 
@@ -11,4 +12,5 @@ public class SmsConfirmation {
   private String qid;
   private Object uacMetadata;
   private boolean scheduled;
+  private Map<String, String> personalisation;
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
@@ -40,6 +40,7 @@ class EmailFulfilmentReceiverIT {
 
   private static final String PACK_CODE = "TEST_EMAIL";
   private static final Map<String, String> TEST_UAC_METADATA = Map.of("TEST_UAC_METADATA", "TEST");
+  private static final Map<String, String> TEST_PERSONALISATION = Map.of("foo", "bar");
 
   @Value("${queueconfig.uac-update-topic}")
   private String uacUpdateTopic;
@@ -75,6 +76,7 @@ class EmailFulfilmentReceiverIT {
     emailConfirmation.setCaseId(testCase.getId());
     emailConfirmation.setPackCode(PACK_CODE);
     emailConfirmation.setUacMetadata(TEST_UAC_METADATA);
+    emailConfirmation.setPersonalisation(TEST_PERSONALISATION);
 
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setEmailConfirmation(emailConfirmation);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverTest.java
@@ -46,6 +46,7 @@ class EmailFulfilmentReceiverTest {
   private static final String TEST_UAC = "TEST_UAC";
   private static final String PACK_CODE = "TEST_EMAIL";
   private static final Map<String, String> TEST_UAC_METADATA = Map.of("TEST_UAC_METADATA", "TEST");
+  private static final Map<String, String> TEST_PERSONALISATION = Map.of("foo", "bar");
 
   private static final String EMAIL_FULFILMENT_DESCRIPTION = "Email fulfilment request received";
 
@@ -54,7 +55,7 @@ class EmailFulfilmentReceiverTest {
     // Given
     Case testCase = new Case();
     testCase.setId(CASE_ID);
-    EventDTO event = buildEnrichedEmailFulfilmentEventWithUacQid();
+    EventDTO event = buildEmailFulfilmentConfirmationEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
     when(caseService.getCase(CASE_ID)).thenReturn(testCase);
@@ -86,7 +87,7 @@ class EmailFulfilmentReceiverTest {
     // Given
     Case testCase = new Case();
     testCase.setId(CASE_ID);
-    EventDTO event = buildEnrichedEmailFulfilmentEvent();
+    EventDTO event = buildEmailFulfilmentConfirmationEvent();
     Message<byte[]> eventMessage = constructMessage(event);
 
     when(caseService.getCase(CASE_ID)).thenReturn(testCase);
@@ -110,7 +111,7 @@ class EmailFulfilmentReceiverTest {
     // Given
     Case testCase = new Case();
     testCase.setId(CASE_ID);
-    EventDTO event = buildEnrichedEmailFulfilmentEventWithUacQid();
+    EventDTO event = buildEmailFulfilmentConfirmationEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
     UacQidLink existingUacQidLink = new UacQidLink();
@@ -139,7 +140,7 @@ class EmailFulfilmentReceiverTest {
     Case otherCase = new Case();
     otherCase.setId(UUID.randomUUID());
 
-    EventDTO event = buildEnrichedEmailFulfilmentEventWithUacQid();
+    EventDTO event = buildEmailFulfilmentConfirmationEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
     UacQidLink existingUacQidLink = new UacQidLink();
@@ -159,18 +160,19 @@ class EmailFulfilmentReceiverTest {
     verifyNoInteractions(eventLogger);
   }
 
-  private EventDTO buildEnrichedEmailFulfilmentEventWithUacQid() {
-    EventDTO event = buildEnrichedEmailFulfilmentEvent();
+  private EventDTO buildEmailFulfilmentConfirmationEventWithUacQid() {
+    EventDTO event = buildEmailFulfilmentConfirmationEvent();
     event.getPayload().getEmailConfirmation().setUac(TEST_UAC);
     event.getPayload().getEmailConfirmation().setQid(TEST_QID);
     return event;
   }
 
-  private EventDTO buildEnrichedEmailFulfilmentEvent() {
+  private EventDTO buildEmailFulfilmentConfirmationEvent() {
     EmailConfirmation emailConfirmation = new EmailConfirmation();
     emailConfirmation.setCaseId(CASE_ID);
     emailConfirmation.setPackCode(PACK_CODE);
     emailConfirmation.setUacMetadata(TEST_UAC_METADATA);
+    emailConfirmation.setPersonalisation(TEST_PERSONALISATION);
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
@@ -40,6 +40,7 @@ class SmsFulfilmentReceiverIT {
 
   private static final String PACK_CODE = "TEST_SMS";
   private static final Map<String, String> TEST_UAC_METADATA = Map.of("TEST_UAC_METADATA", "TEST");
+  private static final Map<String, String> TEST_PERSONALISATION = Map.of("foo", "bar");
 
   @Value("${queueconfig.uac-update-topic}")
   private String uacUpdateTopic;
@@ -75,6 +76,7 @@ class SmsFulfilmentReceiverIT {
     smsConfirmation.setCaseId(testCase.getId());
     smsConfirmation.setPackCode(PACK_CODE);
     smsConfirmation.setUacMetadata(TEST_UAC_METADATA);
+    smsConfirmation.setPersonalisation(TEST_PERSONALISATION);
 
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setSmsConfirmation(smsConfirmation);

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverTest.java
@@ -54,7 +54,7 @@ class SmsFulfilmentReceiverTest {
     // Given
     Case testCase = new Case();
     testCase.setId(CASE_ID);
-    EventDTO event = buildEnrichedSmsFulfilmentEventWithUacQid();
+    EventDTO event = buildSmsFulfilmentConfirmationEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
     when(caseService.getCase(CASE_ID)).thenReturn(testCase);
@@ -82,7 +82,7 @@ class SmsFulfilmentReceiverTest {
     // Given
     Case testCase = new Case();
     testCase.setId(CASE_ID);
-    EventDTO event = buildEnrichedSmsFulfilmentEvent();
+    EventDTO event = buildSmsFulfilmentConfirmationEvent();
     Message<byte[]> eventMessage = constructMessage(event);
 
     when(caseService.getCase(CASE_ID)).thenReturn(testCase);
@@ -102,7 +102,7 @@ class SmsFulfilmentReceiverTest {
     // Given
     Case testCase = new Case();
     testCase.setId(CASE_ID);
-    EventDTO event = buildEnrichedSmsFulfilmentEventWithUacQid();
+    EventDTO event = buildSmsFulfilmentConfirmationEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
     UacQidLink existingUacQidLink = new UacQidLink();
@@ -131,7 +131,7 @@ class SmsFulfilmentReceiverTest {
     Case otherCase = new Case();
     otherCase.setId(UUID.randomUUID());
 
-    EventDTO event = buildEnrichedSmsFulfilmentEventWithUacQid();
+    EventDTO event = buildSmsFulfilmentConfirmationEventWithUacQid();
     Message<byte[]> eventMessage = constructMessage(event);
 
     UacQidLink existingUacQidLink = new UacQidLink();
@@ -151,18 +151,19 @@ class SmsFulfilmentReceiverTest {
     verifyNoInteractions(eventLogger);
   }
 
-  private EventDTO buildEnrichedSmsFulfilmentEventWithUacQid() {
-    EventDTO event = buildEnrichedSmsFulfilmentEvent();
+  private EventDTO buildSmsFulfilmentConfirmationEventWithUacQid() {
+    EventDTO event = buildSmsFulfilmentConfirmationEvent();
     event.getPayload().getSmsConfirmation().setUac(TEST_UAC);
     event.getPayload().getSmsConfirmation().setQid(TEST_QID);
     return event;
   }
 
-  private EventDTO buildEnrichedSmsFulfilmentEvent() {
+  private EventDTO buildSmsFulfilmentConfirmationEvent() {
     SmsConfirmation smsConfirmation = new SmsConfirmation();
     smsConfirmation.setCaseId(CASE_ID);
     smsConfirmation.setPackCode(PACK_CODE);
     smsConfirmation.setUacMetadata(TEST_UAC_METADATA);
+    smsConfirmation.setPersonalisation(Map.of("foo", "bar"));
 
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SMS and email fulfilments can now include personalisation from the request.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add personalisation to SMS and email fulilfment DTO

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run locally with linked branch, personalisation from SMS and email requests should be logged in the events but with redacted values.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/8DGOfdJx/3246-personalisation-on-sms-and-email-fulfilments-8
