### PR TITLE
Moved to eclipse temurin alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM eclipse-temurin:17-jdk-alpine
 ARG JAR_FILE=ssdc-rm-caseprocessor*.jar
 CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-caseprocessor.jar"]
 COPY healthcheck.sh /opt/healthcheck.sh
-RUN addgroup --gid 99 caseprocessor && \
-    adduser --system --uid 99 caseprocessor caseprocessor
+RUN addgroup --gid 1000 caseprocessor && \
+    adduser --system --uid 1000 caseprocessor caseprocessor
 USER caseprocessor
 
 COPY target/$JAR_FILE /opt/ssdc-rm-caseprocessor.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-alpine
 
 ARG JAR_FILE=ssdc-rm-caseprocessor*.jar
-
-CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-caseprocessor.jar"]
+CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-caseprocessor.jar"]
 COPY healthcheck.sh /opt/healthcheck.sh
-RUN groupadd --gid 999 caseprocessor && \
-    useradd --create-home --system --uid 999 --gid caseprocessor caseprocessor
+RUN addgroup --gid 99 caseprocessor && \
+    adduser --system --uid 99 caseprocessor caseprocessor
 USER caseprocessor
 
 COPY target/$JAR_FILE /opt/ssdc-rm-caseprocessor.jar


### PR DESCRIPTION
# Motivation and Context
We currently use a full OpenJDK image for caseprocessor, rather than a slim/alpine version. On top of this the OpenJDK image page recommends not to use it and to instead use one with more support https://hub.docker.com/_/openjdk. We decided on the [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin) image instead.


# What has changed
Changed base image to eclipse temurin alpine and updated Dockerfile to match

# How to test?
Tested by building and running image locally as well as deploying to a dev env and running acceptance tests against it

# Links
https://trello.com/c/XrY9QGaw
