### PR TITLE
621 Add eQ flush action rule processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.16.6</version>
+      <version>4.17.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.17.0-SNAPSHOT</version>
+      <version>4.17.0</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskMessage.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskMessage.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.ssdc.caseprocessor.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CloudTaskMessage {
+  private CloudTaskType cloudTaskType;
+  private CloudTaskPayload payload;
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskMessage.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskMessage.java
@@ -7,5 +7,5 @@ import lombok.Data;
 public class CloudTaskMessage {
   private CloudTaskType cloudTaskType;
   private UUID correlationId;
-  private CloudTaskPayload payload;
+  private Object payload;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskMessage.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskMessage.java
@@ -1,9 +1,11 @@
 package uk.gov.ons.ssdc.caseprocessor.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class CloudTaskMessage {
   private CloudTaskType cloudTaskType;
+  private UUID correlationId;
   private CloudTaskPayload payload;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskPayload.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskPayload.java
@@ -1,0 +1,3 @@
+package uk.gov.ons.ssdc.caseprocessor.model.dto;
+
+public interface CloudTaskPayload {}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskPayload.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskPayload.java
@@ -1,3 +1,0 @@
-package uk.gov.ons.ssdc.caseprocessor.model.dto;
-
-public interface CloudTaskPayload {}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskType.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/CloudTaskType.java
@@ -1,0 +1,5 @@
+package uk.gov.ons.ssdc.caseprocessor.model.dto;
+
+public enum CloudTaskType {
+  EQ_FLUSH
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EqFlushTaskPayload.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EqFlushTaskPayload.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ssdc.caseprocessor.model.dto;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class EqFlushTaskPayload implements CloudTaskPayload {
+  private String qid;
+  private UUID transactionId;
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EqFlushTaskPayload.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/EqFlushTaskPayload.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import lombok.Data;
 
 @Data
-public class EqFlushTaskPayload implements CloudTaskPayload {
+public class EqFlushTaskPayload {
   private String qid;
   private UUID transactionId;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/CaseToProcessProcessor.java
@@ -13,16 +13,19 @@ public class CaseToProcessProcessor {
   private final DeactivateUacProcessor deactivateUacProcessor;
   private final SmsProcessor smsProcessor;
   private final EmailProcessor emailProcessor;
+  private final EqFlushProcessor eqFlushProcessor;
 
   public CaseToProcessProcessor(
       ExportFileProcessor exportFileProcessor,
       DeactivateUacProcessor deactivateUacProcessor,
       SmsProcessor smsProcessor,
-      EmailProcessor emailProcessor) {
+      EmailProcessor emailProcessor,
+      EqFlushProcessor eqFlushProcessor) {
     this.exportFileProcessor = exportFileProcessor;
     this.deactivateUacProcessor = deactivateUacProcessor;
     this.smsProcessor = smsProcessor;
     this.emailProcessor = emailProcessor;
+    this.eqFlushProcessor = eqFlushProcessor;
   }
 
   public void process(CaseToProcess caseToProcess) {
@@ -51,6 +54,9 @@ public class CaseToProcessProcessor {
         break;
       case EMAIL:
         emailProcessor.process(caseToProcess.getCaze(), caseToProcess.getActionRule());
+        break;
+      case EQ_FLUSH:
+        eqFlushProcessor.process(caseToProcess.getCaze(), caseToProcess.getActionRule());
         break;
       default:
         throw new NotImplementedException("No implementation for other types of action rule yet");

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessor.java
@@ -1,0 +1,51 @@
+package uk.gov.ons.ssdc.caseprocessor.service;
+
+import static uk.gov.ons.ssdc.caseprocessor.model.dto.CloudTaskType.EQ_FLUSH;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ssdc.caseprocessor.messaging.MessageSender;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.CloudTaskMessage;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EqFlushTaskPayload;
+import uk.gov.ons.ssdc.common.model.entity.ActionRule;
+import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
+
+@Component
+public class EqFlushProcessor {
+  private final MessageSender messageSender;
+
+  @Value("${queueconfig.cloud-task-queue-topic}")
+  private String cloudTaskQueueTopic;
+
+  public EqFlushProcessor(MessageSender messageSender) {
+    this.messageSender = messageSender;
+  }
+
+  public void process(Case caze, ActionRule actionRule) {
+    List<UacQidLink> uacQidLinks = caze.getUacQidLinks();
+
+    for (UacQidLink uacQidLink : uacQidLinks) {
+      if (uacQidLink.isEqLaunched() && !uacQidLink.isReceiptReceived()) {
+        CloudTaskMessage cloudTaskMessage =
+            prepareEqFlushCloudTaskMessage(uacQidLink, actionRule.getId());
+        messageSender.sendMessage(cloudTaskQueueTopic, cloudTaskMessage);
+      }
+    }
+  }
+
+  private CloudTaskMessage prepareEqFlushCloudTaskMessage(
+      UacQidLink uacQidLink, UUID transactionId) {
+    CloudTaskMessage cloudTaskMessage = new CloudTaskMessage();
+    cloudTaskMessage.setCloudTaskType(EQ_FLUSH);
+
+    EqFlushTaskPayload eqFlushTaskPayload = new EqFlushTaskPayload();
+    eqFlushTaskPayload.setQid(uacQidLink.getQid());
+    eqFlushTaskPayload.setTransactionId(transactionId);
+    cloudTaskMessage.setPayload(eqFlushTaskPayload);
+
+    return cloudTaskMessage;
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessor.java
@@ -40,6 +40,7 @@ public class EqFlushProcessor {
       UacQidLink uacQidLink, UUID transactionId) {
     CloudTaskMessage cloudTaskMessage = new CloudTaskMessage();
     cloudTaskMessage.setCloudTaskType(EQ_FLUSH);
+    cloudTaskMessage.setCorrelationId(transactionId);
 
     EqFlushTaskPayload eqFlushTaskPayload = new EqFlushTaskPayload();
     eqFlushTaskPayload.setQid(uacQidLink.getQid());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,7 @@ queueconfig:
   case-update-topic: event_case-update
   uac-update-topic: event_uac-update
   deactivate-uac-topic: event_deactivate-uac
+  cloud-task-queue-topic: cloud_task_queue
   publishtimeout: 30  # In seconds
   shared-pubsub-project: REPLACEME
 

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleProcessorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ssdc.caseprocessor.schedule;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.time.OffsetDateTime;
@@ -33,7 +32,7 @@ class ActionRuleProcessorTest {
     actionRule.setHasTriggered(true);
     Assertions.assertThat(actualActionRule).isEqualTo(actionRule);
 
-    verify(caseClassifier).enqueueCasesForActionRule(eq(actionRule));
+    verify(caseClassifier).enqueueCasesForActionRule(actionRule);
   }
 
   private ActionRule setUpActionRule(ActionRuleType actionRuleType) {

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessorTest.java
@@ -57,6 +57,7 @@ class EqFlushProcessorTest {
 
     assertThat(messageArgumentCaptor.getValue().getCloudTaskType())
         .isEqualTo(CloudTaskType.EQ_FLUSH);
+    assertThat(messageArgumentCaptor.getValue().getCorrelationId()).isEqualTo(actionRule.getId());
 
     EqFlushTaskPayload cloudTaskPayload =
         (EqFlushTaskPayload) messageArgumentCaptor.getValue().getPayload();

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/EqFlushProcessorTest.java
@@ -1,0 +1,114 @@
+package uk.gov.ons.ssdc.caseprocessor.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ssdc.caseprocessor.messaging.MessageSender;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.CloudTaskMessage;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.CloudTaskType;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.EqFlushTaskPayload;
+import uk.gov.ons.ssdc.common.model.entity.ActionRule;
+import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
+
+@ExtendWith(MockitoExtension.class)
+class EqFlushProcessorTest {
+
+  @Mock private MessageSender messageSender;
+
+  @InjectMocks private EqFlushProcessor underTest;
+
+  @Test
+  void testProcessEqFlushRow() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "cloudTaskQueueTopic", "testTopic");
+
+    Case caze = new Case();
+
+    UacQidLink uacQidLink = new UacQidLink();
+    uacQidLink.setQid("0123456789");
+    uacQidLink.setReceiptReceived(false);
+    uacQidLink.setEqLaunched(true);
+    caze.setUacQidLinks(List.of(uacQidLink));
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setCreatedBy("foo@bar.com");
+
+    // When
+    underTest.process(caze, actionRule);
+
+    // Then
+    ArgumentCaptor<CloudTaskMessage> messageArgumentCaptor =
+        ArgumentCaptor.forClass(CloudTaskMessage.class);
+    verify(messageSender).sendMessage(eq("testTopic"), messageArgumentCaptor.capture());
+
+    assertThat(messageArgumentCaptor.getValue().getCloudTaskType())
+        .isEqualTo(CloudTaskType.EQ_FLUSH);
+
+    EqFlushTaskPayload cloudTaskPayload =
+        (EqFlushTaskPayload) messageArgumentCaptor.getValue().getPayload();
+    assertThat(cloudTaskPayload.getTransactionId()).isEqualTo(actionRule.getId());
+    assertThat(cloudTaskPayload.getQid()).isEqualTo(uacQidLink.getQid());
+  }
+
+  @Test
+  void testProcessEqFlushRowIgnoresReceipted() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "cloudTaskQueueTopic", "testTopic");
+
+    Case caze = new Case();
+
+    UacQidLink uacQidLink = new UacQidLink();
+    uacQidLink.setQid("0123456789");
+    uacQidLink.setReceiptReceived(true);
+    uacQidLink.setEqLaunched(true);
+    caze.setUacQidLinks(List.of(uacQidLink));
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setCreatedBy("foo@bar.com");
+
+    // When
+    underTest.process(caze, actionRule);
+
+    // Then
+    verify(messageSender, never()).sendMessage(any(), any());
+  }
+
+  @Test
+  void testProcessEqFlushRowIgnoresNotLaunched() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "cloudTaskQueueTopic", "testTopic");
+
+    Case caze = new Case();
+
+    UacQidLink uacQidLink = new UacQidLink();
+    uacQidLink.setQid("0123456789");
+    uacQidLink.setReceiptReceived(false);
+    uacQidLink.setEqLaunched(false);
+    caze.setUacQidLinks(List.of(uacQidLink));
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setCreatedBy("foo@bar.com");
+
+    // When
+    underTest.process(caze, actionRule);
+
+    // Then
+    verify(messageSender, never()).sendMessage(any(), any());
+  }
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adds an EQ flush action processor which sends flush cloud task messages for every launched, unreceipted QID linked to the cases it matches.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add EQ flush action processor
- Add cloud task DTO models
- Add tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and run all the branches locally, run the ATs branch. Try creating/running an EQ Flush action rule from support tool.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/sN2EG6Rh/621-eq-flushing-by-action-rule-with-rate-limiting-13
