### PR TITLE
701 Include sensitive case fields in export files

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
@@ -131,10 +131,11 @@ public class ExportFileProcessor {
                     ? personalisation.get(
                         templateItem.substring(REQUEST_PERSONALISATION_PREFIX.length()))
                     : null;
-          } else if(templateItem.startsWith(SENSITIVE_FIELD_PREFIX)) {
-            rowStrings[i] = caze.getSampleSensitive().get(templateItem.substring(SENSITIVE_FIELD_PREFIX.length()));
-          }
-          else {
+          } else if (templateItem.startsWith(SENSITIVE_FIELD_PREFIX)) {
+            rowStrings[i] =
+                caze.getSampleSensitive()
+                    .get(templateItem.substring(SENSITIVE_FIELD_PREFIX.length()));
+          } else {
             rowStrings[i] = caze.getSample().get(templateItem);
           }
       }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.caseprocessor.service;
 
 import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.REQUEST_PERSONALISATION_PREFIX;
+import static uk.gov.ons.ssdc.caseprocessor.utils.Constants.SENSITIVE_FIELD_PREFIX;
 
 import com.opencsv.CSVWriter;
 import java.io.StringWriter;
@@ -130,7 +131,10 @@ public class ExportFileProcessor {
                     ? personalisation.get(
                         templateItem.substring(REQUEST_PERSONALISATION_PREFIX.length()))
                     : null;
-          } else {
+          } else if(templateItem.startsWith(SENSITIVE_FIELD_PREFIX)) {
+            rowStrings[i] = caze.getSampleSensitive().get(templateItem.substring(SENSITIVE_FIELD_PREFIX.length()));
+          }
+          else {
             rowStrings[i] = caze.getSample().get(templateItem);
           }
       }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/Constants.java
@@ -8,4 +8,5 @@ public class Constants {
       Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0", "0.5.0-DRAFT", "0.5.0", "0.6.0-DRAFT");
 
   public static final String REQUEST_PERSONALISATION_PREFIX = "__request__.";
+  public static final String SENSITIVE_FIELD_PREFIX = "__sensitive__.";
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
@@ -153,7 +153,7 @@ class ExportFileProcessorTest {
         null,
         actionRule.getUacMetadata());
 
-    //    // Then
+    // Then
     ArgumentCaptor<ExportFileRow> exportFileRowArgumentCaptor =
         ArgumentCaptor.forClass(ExportFileRow.class);
     verify(exportFileRowRepository).save(exportFileRowArgumentCaptor.capture());

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
@@ -120,6 +120,62 @@ class ExportFileProcessorTest {
   }
 
   @Test
+  void testProcessExportFileRowWithSensitiveField() {
+    // Given
+    Case caze = new Case();
+    caze.setSampleSensitive(Map.of("foo", "bar"));
+    caze.setCaseRef(123L);
+
+    ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
+    exportFileTemplate.setTemplate(new String[] {"__sensitive__.foo"});
+    exportFileTemplate.setPackCode(PACK_CODE);
+    exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setType(ActionRuleType.EXPORT_FILE);
+    actionRule.setExportFileTemplate(exportFileTemplate);
+
+    CaseToProcess caseToProcess = new CaseToProcess();
+    caseToProcess.setActionRule(actionRule);
+    caseToProcess.setCaze(caze);
+    caseToProcess.setBatchId(UUID.fromString("6a127d58-c1cb-489c-a3f5-72014a0c32d6"));
+
+    // When
+    underTest.processExportFileRow(
+        exportFileTemplate.getTemplate(),
+        caze,
+        caseToProcess.getBatchId(),
+        caseToProcess.getBatchQuantity(),
+        exportFileTemplate.getPackCode(),
+        exportFileTemplate.getExportFileDestination(),
+        actionRule.getId(),
+        null,
+        actionRule.getUacMetadata());
+
+    //    // Then
+    ArgumentCaptor<ExportFileRow> exportFileRowArgumentCaptor =
+        ArgumentCaptor.forClass(ExportFileRow.class);
+    verify(exportFileRowRepository).save(exportFileRowArgumentCaptor.capture());
+    ExportFileRow actualExportFileRow = exportFileRowArgumentCaptor.getValue();
+    assertThat(actualExportFileRow.getPackCode()).isEqualTo(PACK_CODE);
+    assertThat(actualExportFileRow.getExportFileDestination()).isEqualTo(EXPORT_FILE_DESTINATION);
+    assertThat(actualExportFileRow.getRow()).isEqualTo("\"bar\"");
+
+    ArgumentCaptor<EventDTO> eventCaptor = ArgumentCaptor.forClass(EventDTO.class);
+    verify(eventLogger)
+        .logCaseEvent(
+            eq(caze),
+            eq("Export file generated with pack code " + PACK_CODE),
+            eq(EventType.EXPORT_FILE),
+            eventCaptor.capture(),
+            any(OffsetDateTime.class));
+
+    EventHeaderDTO actualHeader = eventCaptor.getValue().getHeader();
+    Assertions.assertThat(actualHeader.getCorrelationId()).isEqualTo(actionRule.getId());
+  }
+
+  @Test
   void testProcessFulfilment() {
     // Given
     ExportFileTemplate exportFileTemplate = new ExportFileTemplate();


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Export files needs to include sensitive data fields, when they are specifically addressed with a `__sensitive__.` prefix in the template.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Include sensitive data fields in export file when addressed with `__sensitive__.` prefix in template

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and run linked ATs branch

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/WjIn0q5p/701-defect-information-marked-as-sensitive-missing-in-the-print-files
