### PR TITLE
813 Log payload containing pack code in EXPORT_FILE events

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/ExportFileDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/ExportFileDTO.java
@@ -1,0 +1,8 @@
+package uk.gov.ons.ssdc.caseprocessor.model.dto;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ExportFileDTO {
+  private String packCode;
+}

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/ExportFileDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/ExportFileDTO.java
@@ -1,8 +1,12 @@
 package uk.gov.ons.ssdc.caseprocessor.model.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class ExportFileDTO {
   private String packCode;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/dto/PayloadDTO.java
@@ -23,4 +23,5 @@ public class PayloadDTO {
   private NewCase newCase;
   private SmsRequest smsRequest;
   private EmailRequest emailRequest;
+  private ExportFileDTO exportFile;
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 import uk.gov.ons.ssdc.caseprocessor.cache.UacQidCache;
 import uk.gov.ons.ssdc.caseprocessor.collectioninstrument.CollectionInstrumentHelper;
 import uk.gov.ons.ssdc.caseprocessor.logging.EventLogger;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.ExportFileDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.UacQidDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.repository.ExportFileRowRepository;
 import uk.gov.ons.ssdc.caseprocessor.utils.EventHelper;
@@ -150,11 +152,15 @@ public class ExportFileProcessor {
 
     exportFileRowRepository.save(exportFileRow);
 
+    PayloadDTO exportFilePayload = new PayloadDTO();
+    ExportFileDTO exportFileDTO = new ExportFileDTO(packCode);
+    exportFilePayload.setExportFile(exportFileDTO);
+
     eventLogger.logCaseEvent(
         caze,
         String.format("Export file generated with pack code %s", packCode),
         EventType.EXPORT_FILE,
-        EventHelper.getDummyEvent(correlationId, originatingUser),
+        EventHelper.getDummyEvent(correlationId, originatingUser, exportFilePayload),
         OffsetDateTime.now());
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/utils/EventHelper.java
@@ -6,6 +6,7 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.ssdc.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.ssdc.caseprocessor.model.dto.PayloadDTO;
 
 public class EventHelper {
 
@@ -38,6 +39,11 @@ public class EventHelper {
   }
 
   public static EventDTO getDummyEvent(UUID correlationId, String originatingUser) {
+    return getDummyEvent(correlationId, originatingUser, null);
+  }
+
+  public static EventDTO getDummyEvent(
+      UUID correlationId, String originatingUser, PayloadDTO payloadDTO) {
     EventHeaderDTO eventHeader = new EventHeaderDTO();
 
     eventHeader.setChannel(EVENT_CHANNEL);
@@ -49,6 +55,7 @@ public class EventHelper {
 
     EventDTO event = new EventDTO();
     event.setHeader(eventHeader);
+    event.setPayload(payloadDTO);
 
     return event;
   }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
@@ -117,7 +117,8 @@ class ExportFileProcessorTest {
 
     EventDTO actualEvent = eventCaptor.getValue();
     Assertions.assertThat(actualEvent.getHeader().getCorrelationId()).isEqualTo(actionRule.getId());
-    Assertions.assertThat(actualEvent.getPayload().getExportFile().getPackCode()).isEqualTo(PACK_CODE);
+    Assertions.assertThat(actualEvent.getPayload().getExportFile().getPackCode())
+        .isEqualTo(PACK_CODE);
   }
 
   @Test
@@ -174,8 +175,8 @@ class ExportFileProcessorTest {
 
     EventDTO actualEvent = eventCaptor.getValue();
     Assertions.assertThat(actualEvent.getHeader().getCorrelationId()).isEqualTo(actionRule.getId());
-    Assertions.assertThat(actualEvent.getPayload().getExportFile().getPackCode()).isEqualTo(PACK_CODE);
-
+    Assertions.assertThat(actualEvent.getPayload().getExportFile().getPackCode())
+        .isEqualTo(PACK_CODE);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
@@ -115,8 +115,9 @@ class ExportFileProcessorTest {
             eventCaptor.capture(),
             any(OffsetDateTime.class));
 
-    EventHeaderDTO actualHeader = eventCaptor.getValue().getHeader();
-    Assertions.assertThat(actualHeader.getCorrelationId()).isEqualTo(actionRule.getId());
+    EventDTO actualEvent = eventCaptor.getValue();
+    Assertions.assertThat(actualEvent.getHeader().getCorrelationId()).isEqualTo(actionRule.getId());
+    Assertions.assertThat(actualEvent.getPayload().getExportFile().getPackCode()).isEqualTo(PACK_CODE);
   }
 
   @Test
@@ -171,8 +172,10 @@ class ExportFileProcessorTest {
             eventCaptor.capture(),
             any(OffsetDateTime.class));
 
-    EventHeaderDTO actualHeader = eventCaptor.getValue().getHeader();
-    Assertions.assertThat(actualHeader.getCorrelationId()).isEqualTo(actionRule.getId());
+    EventDTO actualEvent = eventCaptor.getValue();
+    Assertions.assertThat(actualEvent.getHeader().getCorrelationId()).isEqualTo(actionRule.getId());
+    Assertions.assertThat(actualEvent.getPayload().getExportFile().getPackCode()).isEqualTo(PACK_CODE);
+
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need the pack code to be logged in a query-able manner on `EXPORT_FILE` events. Putting it in the payload in the same format as we store it for other inbound events that we log is a simple solution.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Store the export file pack code in the event payload of `EXPORT_FILE` events
- Update unit tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the code, run locally, run an export file action rule, check the events have the pack code in the payload.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Ve49M0OO/813-send-mi-to-phm-print-counts-5
