### PR TITLE
1146 Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Motivation and Context
Dependabot PR isn't working for java repos

# What has changed
Added a dependabot.yml file to tell dependabot to use mvn 
This is a test to for a spike ([1146 Dependabot PR Spike](https://github.com/ONSdigital/ssdc-rm-documentation/pull/196))

# How to test?
Check its ok

# Links
[1146 Dependabot PR Spike](https://github.com/ONSdigital/ssdc-rm-documentation/pull/196)
https://trello.com/c/yzSbsXXs

# Screenshots (if appropriate):
