### PR TITLE
1247 custom docker compose script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "daily"
     labels:
       - "patch"
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "patch"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: install docker-build
 build-no-test: install-no-test docker-build
 
 install-no-test:
-	mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true
+	mvn clean install -Dmaven.test.skip=true -Dexec.skip=true
 
 format:
 	mvn fmt:format

--- a/pom.xml
+++ b/pom.xml
@@ -192,30 +192,30 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.dkanejs.maven.plugins</groupId>
-        <artifactId>docker-compose-maven-plugin</artifactId>
-        <version>4.0.0</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
-            <id>up</id>
+            <id>Docker Compose Up</id>
             <phase>pre-integration-test</phase>
             <goals>
-              <goal>up</goal>
+              <goal>exec</goal>
             </goals>
             <configuration>
-              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
-              <detachedMode>true</detachedMode>
+              <executable>docker</executable>
+              <commandlineArgs>compose -f src/test/resources/docker-compose.yml up -d</commandlineArgs>
             </configuration>
           </execution>
           <execution>
-            <id>down</id>
+            <id>Docker Compose Down</id>
             <phase>post-integration-test</phase>
             <goals>
-              <goal>down</goal>
+              <goal>exec</goal>
             </goals>
             <configuration>
-              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
-              <removeVolumes>true</removeVolumes>
+              <executable>docker</executable>
+              <commandlineArgs>compose -f src/test/resources/docker-compose.yml down -v</commandlineArgs>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -192,31 +192,35 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.dkanejs.maven.plugins</groupId>
-        <artifactId>docker-compose-maven-plugin</artifactId>
-        <version>4.0.0</version>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.43.4</version>
+        <configuration>
+          <image>
+            <name>ssdc-rm-dev-common-postgres:latest</name>
+            <exernal>
+              <type>compose</type>
+              <basedir>${project.basedir}/src/test/resources</basedir>
+              <composeFile>docker-compose.yml</composeFile>
+            </exernal>
+          </image>
+          <removeVolumes>true</removeVolumes>
+        </configuration>
         <executions>
           <execution>
-            <id>up</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>up</goal>
-            </goals>
-            <configuration>
-              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
-              <detachedMode>true</detachedMode>
-            </configuration>
+          <id>start</id>
+          <phase>pre-integration-test</phase>
+          <goals>
+            <goal>build</goal>
+            <goal>start</goal>
+          </goals>
           </execution>
           <execution>
-            <id>down</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>down</goal>
-            </goals>
-            <configuration>
-              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
-              <removeVolumes>true</removeVolumes>
-            </configuration>
+          <id>stop</id>
+          <phase>post-integration-test</phase>
+          <goals>
+            <goal>stop</goal>
+          </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -192,35 +192,31 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <version>0.43.4</version>
-        <configuration>
-          <image>
-            <name>ssdc-rm-dev-common-postgres:latest</name>
-            <exernal>
-              <type>compose</type>
-              <basedir>${project.basedir}/src/test/resources</basedir>
-              <composeFile>docker-compose.yml</composeFile>
-            </exernal>
-          </image>
-          <removeVolumes>true</removeVolumes>
-        </configuration>
+        <groupId>com.dkanejs.maven.plugins</groupId>
+        <artifactId>docker-compose-maven-plugin</artifactId>
+        <version>4.0.0</version>
         <executions>
           <execution>
-          <id>start</id>
-          <phase>pre-integration-test</phase>
-          <goals>
-            <goal>build</goal>
-            <goal>start</goal>
-          </goals>
+            <id>up</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>up</goal>
+            </goals>
+            <configuration>
+              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
+              <detachedMode>true</detachedMode>
+            </configuration>
           </execution>
           <execution>
-          <id>stop</id>
-          <phase>post-integration-test</phase>
-          <goals>
-            <goal>stop</goal>
-          </goals>
+            <id>down</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>down</goal>
+            </goals>
+            <configuration>
+              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
+              <removeVolumes>true</removeVolumes>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
# Motivation and Context
The maven plugin we use for docker compose on our java projects is no longer compatible and we concluded the best solution was to create a custom script to replace this.

# What has changed
Changed the original plugin to a custom one
Amended make command that skips docker compose 

# How to test?
Check it works locally on your machine

# Links
(https://trello.com/c/yOWPLr4O)

# Screenshots (if appropriate):