### PR TITLE
Ignore patch updates for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
     labels:
       - "patch"
       - "dependencies"


### PR DESCRIPTION
# Motivation and Context
Dependabot currently raises PRs for all version updates, which is becoming too much for us to handle. 

# What has changed
Patch version updates are now ignored, which should hopefully reduce the number of PRs raised.

# How to test?
Merge it in and hope that the number of PRs reduces to a manageable level.  If it does then we can roll it out to other repos.

# Links
https://trello.com/c/JlchVJUn
