### PR TITLE
Update github-pr-label-checker to latest available version 1.6.13

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: docker://onsdigital/github-pr-label-checker:v1.2.7
+      - uses: docker://onsdigital/github-pr-label-checker:v1.6.13
         with:
           one_of: breaking change,feature,patch
           none_of: do not merge,work in progress


### PR DESCRIPTION
# Motivation and Context
We're currently using version 1.2.7 of the github-pr-label-checker, which is a log way behind the most recent version 1.6.13.  Version 1.2.7 uses features that are now deprecated.

For info, Dependabot has already been set to avoid patch updates for this repo.

# What has changed
Updated the version of the label checker in the Git workflow.

# How to test?
This PR is the test.  I'll first allow it to run without a valid label then will add a label and allow it to re-run. It should continue to work as it always has.

# Links
https://trello.com/c/TDpQHGaw
