### PR TITLE
store count of selected cases against action rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.19.0</version>
+      <version>4.20.0</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleProcessor.java
@@ -20,8 +20,9 @@ public class ActionRuleProcessor {
   @Transactional(
       propagation = Propagation.REQUIRES_NEW) // Start a new transaction for every action rule
   public void processTriggeredActionRule(ActionRule triggeredActionRule) {
-    caseClassifier.enqueueCasesForActionRule(triggeredActionRule);
+    int casesSelected = caseClassifier.enqueueCasesForActionRule(triggeredActionRule);
     triggeredActionRule.setHasTriggered(true);
+    triggeredActionRule.setSelectedCaseCount(casesSelected);
     actionRuleRepository.save(triggeredActionRule);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/CaseClassifier.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/schedule/CaseClassifier.java
@@ -14,10 +14,10 @@ public class CaseClassifier {
     this.jdbcTemplate = jdbcTemplate;
   }
 
-  public void enqueueCasesForActionRule(ActionRule actionRule) {
+  public int enqueueCasesForActionRule(ActionRule actionRule) {
     UUID batchId = UUID.randomUUID();
 
-    jdbcTemplate.update(
+    return jdbcTemplate.update(
         "INSERT INTO casev3.case_to_process (batch_id, batch_quantity, action_rule_id, "
             + "caze_id) SELECT ?, COUNT(*) OVER (), ?, id FROM "
             + "casev3.cases "

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/schedule/ActionRuleIT.java
@@ -262,6 +262,7 @@ class ActionRuleIT {
     actionRule.setCreatedBy(CREATED_BY_USER);
     actionRule.setUacMetadata(TEST_UAC_METADATA);
     actionRule.setClassifiers(classifiers);
+    actionRule.setSelectedCaseCount(0);
 
     if (smsTemplate != null) {
       actionRule.setSmsTemplate(smsTemplate);


### PR DESCRIPTION
# Motivation and Context
It would be useful to be able to see how many cases each action rule has selected in the support tool UI

# What has changed
Stored the number of selected cases returned by the case queuer against the respective action rule in the DB

# How to test?
Create a survey/CE/action rule in support tool and load a valid sample against it
Click the dry run button against the action rule and note how many cases should be picked up by that action rule
Wait for the rule to trigger and check that the number displayed against it in the 'Selected Cases' column is the same
