### PR TITLE
SDCSRM-487 Removing questionnaire type

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/cache/UacQidCache.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/cache/UacQidCache.java
@@ -1,6 +1,10 @@
 package uk.gov.ons.ssdc.caseprocessor.cache;
 
-import java.util.concurrent.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/cache/UacQidCache.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/cache/UacQidCache.java
@@ -67,6 +67,8 @@ public class UacQidCache {
   }
 
   private void topUpCache() {
+    // We use synchronised on an empty object instead of the isToppingUpCache bool because it's
+    // bad practice to use it on a boolean literal.
     synchronized (lock) {
       if (!isToppingUpCache && uacQidLinkCache.size() < cacheMin) {
         isToppingUpCache = true;

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/client/UacQidServiceClient.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/client/UacQidServiceClient.java
@@ -23,25 +23,23 @@ public class UacQidServiceClient {
   @Value("${uacservice.connection.port}")
   private String port;
 
-  public List<UacQidDTO> getUacQids(Integer questionnaireType, int numberToCreate) {
+  public List<UacQidDTO> getUacQids( int numberToCreate) {
     RestTemplate restTemplate = new RestTemplate();
 
     UriComponents uriComponents =
-        createUriComponents(questionnaireType, numberToCreate, "multiple_qids");
+        createUriComponents(numberToCreate, "multiple_qids");
     ResponseEntity<UacQidDTO[]> responseEntity =
         restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, null, UacQidDTO[].class);
 
     return Arrays.asList(responseEntity.getBody());
   }
 
-  private UriComponents createUriComponents(
-      int questionnaireType, int numberToCreate, String path) {
+  private UriComponents createUriComponents(int numberToCreate, String path) {
     return UriComponentsBuilder.newInstance()
         .scheme(scheme)
         .host(host)
         .port(port)
         .path(path)
-        .queryParam("questionnaireType", questionnaireType)
         .queryParam("numberToCreate", numberToCreate)
         .build()
         .encode();

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/client/UacQidServiceClient.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/client/UacQidServiceClient.java
@@ -23,11 +23,10 @@ public class UacQidServiceClient {
   @Value("${uacservice.connection.port}")
   private String port;
 
-  public List<UacQidDTO> getUacQids( int numberToCreate) {
+  public List<UacQidDTO> getUacQids(int numberToCreate) {
     RestTemplate restTemplate = new RestTemplate();
 
-    UriComponents uriComponents =
-        createUriComponents(numberToCreate, "multiple_qids");
+    UriComponents uriComponents = createUriComponents(numberToCreate, "multiple_qids");
     ResponseEntity<UacQidDTO[]> responseEntity =
         restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, null, UacQidDTO[].class);
 

--- a/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessor.java
@@ -178,7 +178,7 @@ public class ExportFileProcessor {
     String collectionInstrumentUrl =
         collectionInstrumentHelper.getCollectionInstrumentUrl(caze, metadata);
 
-    UacQidDTO uacQidDTO = uacQidCache.getUacQidPair(1);
+    UacQidDTO uacQidDTO = uacQidCache.getUacQidPair();
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setQid(uacQidDTO.getQid());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,6 +6,6 @@ spring:
         project-id: our-project
 
 queueconfig:
-  shared-pubsub-project: shared-project
+  shared-pubsub-project: our-project
 
 caserefgeneratorkey: abc123

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/cache/UacQidCacheTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/cache/UacQidCacheTest.java
@@ -38,9 +38,9 @@ public class UacQidCacheTest {
     uacQidDTO1.setQid("54321");
     listUacDtos.add(uacQidDTO2);
 
-    when(uacQidServiceClient.getUacQids(1, 2)).thenReturn(listUacDtos);
+    when(uacQidServiceClient.getUacQids(2)).thenReturn(listUacDtos);
 
-    UacQidDTO actualUacDto = underTest.getUacQidPair(1);
+    UacQidDTO actualUacDto = underTest.getUacQidPair();
     assertThat(actualUacDto.getQid()).isEqualTo(uacQidDTO1.getQid());
   }
 
@@ -52,12 +52,10 @@ public class UacQidCacheTest {
 
     List<UacQidDTO> listUacDtos = new ArrayList<>();
 
-    when(uacQidServiceClient.getUacQids(1, 2)).thenReturn(listUacDtos);
+    when(uacQidServiceClient.getUacQids(2)).thenReturn(listUacDtos);
 
-    RuntimeException thrown =
-        assertThrows(RuntimeException.class, () -> underTest.getUacQidPair(1));
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> underTest.getUacQidPair());
 
-    Assertions.assertThat(thrown.getMessage())
-        .isEqualTo("Timeout getting UacQidDTO for questionnaireType :1");
+    Assertions.assertThat(thrown.getMessage()).isEqualTo("Timeout getting UacQidDTO");
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
@@ -63,7 +63,7 @@ class EmailFulfilmentReceiverIT {
   void testEmailFulfilment() throws Exception {
     // Given
     // Get a new UAC QID pair
-    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1, 1);
+    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1);
     UacQidDTO emailUacQid = uacQidDTOList.get(0);
 
     // Create the case

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
@@ -63,7 +63,7 @@ class SmsFulfilmentReceiverIT {
   void testSmsFulfilment() throws Exception {
     // Given
     // Get a new UAC QID pair
-    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1, 1);
+    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1);
     UacQidDTO smsUacQid = uacQidDTOList.get(0);
 
     // Create the case

--- a/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/caseprocessor/service/ExportFileProcessorTest.java
@@ -69,7 +69,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
     when(collectionInstrumentHelper.getCollectionInstrumentUrl(caze, TEST_UAC_METADATA))
         .thenReturn("testCollectionInstrumentUrl");
 
@@ -204,7 +204,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
 
     // When
     underTest.process(fulfilmentToProcess);
@@ -270,7 +270,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
 
     // When
     underTest.process(fulfilmentToProcess);
@@ -335,7 +335,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
 
     // When
     underTest.process(fulfilmentToProcess);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We've decided that the questionnaire type doesn't need to be used as part of the qid now so we can remove it from the services requesting uacqid pairs. In Case Processor, this is a more involved change since the questionnaire type was used around the uacqid caching so that had to be changed slightly. It now locks on an object so whichever thread can lock on that object, can access the cache to top it up.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Removed questionnaire type from the uacqid cache
- Changed the uacQidLinkQueueMap to just a blocking queue since there's no type to store uacs under.
- Changed the `shared-pubsub-project` variable in the dev application to our-project so it should work straight away instead of having to change the values.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- If the [uac-qid PR](https://github.com/ONSdigital/ssdc-rm-uac-qid-service/pull/64) hasn't been merged yet, checkout the branch and build it
- Build the branch and the others attached to the ticket
- Run the ATs
- Check the QIDs in the DB, there shouldn't be a questionnaire type(01) at the start of it
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-487)
