### PR TITLE
SDCSRM-542 Dependabot Security Only PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch", "version-update:semver-minor" ]
-    labels:
-      - "patch"
-      - "dependencies"
+    - package-ecosystem: "maven"
+      directory: "/"
+      target-branch: "main"
+      groups:
+        maven-security-updates:
+          applies-to: "security-updates"
+          patterns:
+            - "*"
+      schedule:
+        interval: "daily"
+      labels:
+        - "patch"
+        - "dependencies"


### PR DESCRIPTION
# Motivation and Context
We want to limit the amount of dependabot PRs

# What has changed
Enabled grouping and only allowed security PRs

# How to test?
Check it looks ok

# Links
[SDCSRM-542](https://jira.ons.gov.uk/browse/SDCSRM-542)