### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -47,10 +47,10 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 ARG JAR_FILE=ssdc-rm-caseprocessor*.jar
 CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-caseprocessor.jar"]

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ install-no-test:
 	CONTAINER_CLI=$(DOCKER) mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
 
 format:
-	mvn fmt:format
+	mvn spotless:apply
 
 format-check:
-	mvn fmt:check
+	mvn spotless:check
 
 check:
-	mvn fmt:check pmd:check
+	mvn spotless:check pmd:check
 
 test:
 	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.release>21</maven.compiler.release>
     <java.version>21</java.version>
     <container.cli>docker</container.cli>
   </properties>
@@ -198,7 +197,7 @@
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.24.0</version>
         <configuration>
-          <targetJdk>21</targetJdk>
+          <targetJdk>${java.version}</targetJdk>
           <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
@@ -339,8 +338,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>21</source>
-          <target>21</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <encoding>UTF-8</encoding>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,8 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
+    <java.version>21</java.version>
     <container.cli>docker</container.cli>
   </properties>
 
@@ -195,8 +196,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.21.2</version>
+        <version>3.24.0</version>
         <configuration>
+          <targetJdk>21</targetJdk>
           <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
@@ -273,15 +275,24 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Spotless (replacement for fmt-maven-plugin) -->
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.13</version>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.43.0</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.22.0</version> <!-- Java 21 compatible -->
+            </googleJavaFormat>
+          </java>
+        </configuration>
         <executions>
           <execution>
             <goals>
-              <goal>format</goal>
+              <goal>check</goal>
             </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>
@@ -328,8 +339,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>21</source>
+          <target>21</target>
           <encoding>UTF-8</encoding>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>


### PR DESCRIPTION
# Motivation and Context
Upgrade to Java 21 from 17.

# What has changed
- Upgraded to use Java 21 in the pom and to build using the Java 21 docker image.
- Updated checks to use spotless rather than fmt
- Updated Git Actions file to use Java 21

# How to test?
- Install Java 21 locally using the dev-tools install script (currently in PR)
- All checks and tests should pass
- The docker image should build fine and should run in docker-dev with no issues

# Links
[SDCSRM-1570](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570)
https://github.com/ONSdigital/ssdc-rm-dev-tools/pull/176


[SDCSRM-1570]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ